### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/Arduino/libraries/SmartThings/README.md
+++ b/Arduino/libraries/SmartThings/README.md
@@ -33,18 +33,18 @@ SmartThings library consists of:
   -On_Off_LED_Ethernet.device.groovy for use with an Arduino/W5100 combo OR Arduino/ESP-01 combo OR a NodeMCU ESP8266 board OR a ESP-01 module
 
 
-##SmartThings Library Installation Instructions
+## SmartThings Library Installation Instructions
 - Download the SmartThings library and copy it to your your Arduino "libraries" folder
   - On Windows, it's located in `C:\My Documents\Arduino\libraries`
   - On Mac, it's located in `~/Documents/Arduino/libraries`
   - Restart the Arduino IDE so it will scan the new library
   - Assumption: If you're using an ESP8266 based board, you should already have added support for it to the IDE (Google it if needed.)
 
-##Pre-Requisites for using Ethernet based connectivity (Arduino/W5100, Arduino/ESP-01, NodeMCU ESP8266, ESP-01)
+## Pre-Requisites for using Ethernet based connectivity (Arduino/W5100, Arduino/ESP-01, NodeMCU ESP8266, ESP-01)
 - Your SmartThings HUB must have a Static TCP/IP Address assigned via your router's DHCP Server.  Since this procedure varies by router model, Google it!
 - You'll need to identify a static TCP/IP address for your Arduino/W5100, Arduino/ESP-01, NodeMCU ESP8266, or ESP-01, as you'll need this later when setting up the sketch.  Choose an unused IP address outside of the range your router's DHCP server uses.
   
-##Arduino IDE Instructions
+## Arduino IDE Instructions
 - Open the Arduino IDE and select File->Examples->SmartThings
   - Select the example sketch that matches your hardware
   - Select File->Save As and select your "Sketches" folder, and click "Save"
@@ -56,7 +56,7 @@ SmartThings library consists of:
   - With the Serial Monitor windows open, load your sketch and watch the output
     - If using an Arduino/ESP-01, NodeMCU ESP8266 board, or ESP-01 the MAC Address will be printed out in the serial monitor window.  Write this down as you will need it to configure the Device using your ST App on your phone. (Note: MAC Address must later be entered with no delimeters in the form of "06AB23CD45EF" (without quotes!))
   
-##SmartThings IDE Device Handler Installation Instructions
+## SmartThings IDE Device Handler Installation Instructions
 - Create an account and/or log into the SmartThings Developers Web IDE.
 
 Arduino/ThingShield
@@ -106,7 +106,7 @@ Ethernet Arduino/W5100, Arduino/ESP-01, NodeMCU ESP8266, or ESP-01
 .
 .
 
-###WARNING - Geeky Material Ahead!!!
+### WARNING - Geeky Material Ahead!!!
 
 .
 .

--- a/Arduino/libraries/WiFiEsp/README.md
+++ b/Arduino/libraries/WiFiEsp/README.md
@@ -7,20 +7,20 @@ The WiFiEsp library is very similar to the Arduino [WiFi](http://www.arduino.cc/
 Supports ESP SDK version 1.1.1 and above (AT version 0.25 and above).
 
 
-##Features
+## Features
 
 - APIs compatible with standard Arduino WiFi library.
 - Use AT commands of standard ESP firmware (no need to flash a custom firmware).
 - Support hardware and software serial ports.
 - Configurable tracing level.
 
-##Wiring
+## Wiring
 
 The WiFiEsp library has been designed to work with the [ESP WiFi shield](http://www.instructables.com/id/Cheap-Arduino-WiFi-Shield-With-ESP8266/).
 It is a cheap version of the Arduino WiFi shield that uses an ESP-01 module to provide networking capabilities to Arduino boards.
 
 
-##Examples
+## Examples
 
 - [ConnectWPA](https://github.com/bportaluri/WiFiEsp/blob/master/examples/ConnectWPA/ConnectWPA.ino) - Demonstrates how to connect to a network that is encrypted with WPA2 Personal
 - [WebClient](https://github.com/bportaluri/WiFiEsp/blob/master/examples/WebClient/WebClient.ino) - Connect to a remote webserver 
@@ -31,11 +31,11 @@ It is a cheap version of the Arduino WiFi shield that uses an ESP-01 module to p
 - [UdpNTPClient](https://github.com/bportaluri/WiFiEsp/blob/master/examples/UdpNTPClient/UdpNTPClient.ino) - Query a Network Time Protocol (NTP) server using UDP
 
 
-##Supported APIs
+## Supported APIs
 
 Most of the standard Arduino WiFi library methods are available. Refer to the [WiFi library page](http://www.arduino.cc/en/Reference/WiFi) for more details.
 
-###WiFiEsp class
+### WiFiEsp class
 
 - begin() - Not all authentication types
 - disconnect() - YES
@@ -50,7 +50,7 @@ Most of the standard Arduino WiFi library methods are available. Refer to the [W
 - macAddress() - YES
 
 
-###WiFiEspServer class
+### WiFiEspServer class
 
 The WiFiEspServer class creates servers which can send data to and receive data from connected clients (programs running on other computers or devices).
 
@@ -62,7 +62,7 @@ The WiFiEspServer class creates servers which can send data to and receive data 
 - println() - YES
 
 
-###Client class
+### Client class
 
 The WiFiEspClient class creates clients that can connect to servers and send and receive data.
 
@@ -78,7 +78,7 @@ The WiFiEspClient class creates clients that can connect to servers and send and
 - stop() - YES
 
 
-###WiFiEspUDP class
+### WiFiEspUDP class
 
 The UDP class enables UDP message to be sent and received.
 
@@ -97,6 +97,6 @@ The UDP class enables UDP message to be sent and received.
 - remotePort() - YES
 
 
-##Contributing
+## Contributing
 
 If you discover a bug or would like to propose a new feature, please open a new [issue](https://github.com/bportaluri/WiFiEsp/issues).

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ ST_Anything (original example) consists of four parts:
   - ST_Anything_ThingShield.device.groovy (ThingShield)
   - ST_Anything_Ethernet.device.groovy (Arduino/W5100, Arduino/ESP-01, NodeMCU ESP8266-12e, ESP-01) 
 
-##ST_Anything Arduino IDE Setup Instructions 
+## ST_Anything Arduino IDE Setup Instructions 
 - Download the ST_Anything repository.
 - This folder structure should mirror that of your local Arduino directory. 
   - On Mac, it's located in `~/Documents/Arduino/`.
@@ -76,7 +76,7 @@ ST_Anything (original example) consists of four parts:
 - Open one of the ST_Anything_xxxxx.ino sketches for the hardware you're using and see if it successfully compiles.
 - WARNING:  If you are using an Arduino UNO, you may need to comment out some of the devices in the sketch (both in the global variable declaration section as well as the setup() function) due to the UNO's limited 2 kilobytes of SRAM.  Failing to do so will most likely result in unpredictable behavior. The Arduino MEGA 2560 has 8k of SRAM and has four Hardware Serial ports (UARTs).  If you plan on using lots of devices, get the MEGA 2560.
 
-##ST_Anything SmartThings Device Handler Installation Instructions - FOR USE WITH A THINGSHIELD
+## ST_Anything SmartThings Device Handler Installation Instructions - FOR USE WITH A THINGSHIELD
 - Join your Arduino/ThingShield to your hub using your phone's SmartThings App.  It will show up as a generic "Arduino ThingShield"
 - Create an account and/or log into the SmartThings Developers Web IDE.
 - Click on "My Device Handlers" from the navigation menu.
@@ -97,15 +97,15 @@ ST_Anything (original example) consists of four parts:
 - Be sure to go into the Preferences section to set the polling rates for the sensors.  These are sent to the Arduino if you press the Configure tile.  (Note:  Currently, these settings do not persist after an Arduino reboot.)
 
 
-##Ethernet (Arduino/W5100, Arduino/ESP-01, and ESP8266) Examples
+## Ethernet (Arduino/W5100, Arduino/ESP-01, and ESP8266) Examples
 The steps for using the Arduino/W5100, Arduino/ESP-01, and NodeMCU ESP8266 sample code is very similar to above, with the added steps of static IP assignements, MAC addresses, SSID and Passwords, etc...
 For now, please refer to the SmartThings library's Readme.md for these details https://github.com/DanielOgorchock/ST_Anything/tree/master/Arduino/libraries/SmartThings 
 
 
-##Updated SmartThings ThingShield Library
+## Updated SmartThings ThingShield Library
 As mentioned previously, the "SmartThings" v2.x library was extensively modified for Ethernet support.  Please see the readme.md file for that particular library for more detailed information. 
 
-##How do I create and expose more than 1 of a single capability?
+## How do I create and expose more than 1 of a single capability?
 By default, SmartThings only allows each device to have one of each capability.  That means you can't create a device with 6 "Contact Sensor" capabilities and have normal SmartApps be able to use each of the 6 sensors for normal processing.  There is a work-around for this which I call a Multiplexer SmartApp.  When used in conjuction with a virtual device for each of the 6 Arduino "Contact Sensor" devices, we can finally allow normal SmartApps to interact with each sensor, switch, etc..
 
 As an example, here are the basic steps to use "ST_Anything_Doors_ThingShield"
@@ -140,7 +140,7 @@ Basically, what is happening here is the following:
 
 -Any other smart apps that are looking at the virtual contact sensor devices will then receive an update and act accordingly.
 
-##Items to be aware of
+## Items to be aware of
 1) Please do not start editing any code before getting one of the examples up and running on both the Arduino/ESP8266 and the Device Handler.  It is always best to start with known working code before editing it.  This greatly reduces the amount of troubleshooting later.
 
 2) The names of the devices you create in the Arduino setup() routine must match exactly the names of the tiles (and custom attributes) in the Device Handler code.  The names are CaSe SenSiTiVe!  
@@ -149,7 +149,7 @@ Basically, what is happening here is the following:
 
 4) When entering the MAC address into the Device Prerences in your phone's SmartThings App, please be sure to enter it without delimiters, and in uppercase.  It should be in the form '06AB02CD03EF' without the quotes.  If using the W5100, get the MAC address from the sketch.  If using an ESP8266 based solution, the MAC address of the onboard WiFi will be printed out in the Arduino IDE Serial Monitor window (9600 baud).
 
-##Final Notes for now...
+## Final Notes for now...
 Plese refer to the header files of the ST_Anything library for explanation of specific classes, constructor arguments, etc... 
 
 Look at the documentation in the 'ST_Anything_ThingShield.ino' file for explanation of general use of the library.  


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
