### PR TITLE
Update parent-st-anything-ethernet.groovy

### DIFF
--- a/devicetypes/ogiewon/parent-st-anything-ethernet.src/parent-st-anything-ethernet.groovy
+++ b/devicetypes/ogiewon/parent-st-anything-ethernet.src/parent-st-anything-ethernet.groovy
@@ -23,7 +23,7 @@
  *    2017-06-10  Dan Ogorchock  Added Dimmer Switch support
  *    2017-07-09  Dan Ogorchock  Added number of defined buttons tile
  *    2017-08-24  Allan (vseven) Change the way values are pushed to child devices to allow a event to be executed allowing future customization
- *
+ * 
  */
  
 metadata {
@@ -263,6 +263,12 @@ void childSetLevel(String dni, value) {
     sendEthernet("${name} ${value}")
 }
 
+void childSetColor(String dni, value) {
+    def name = dni.split("-")[-1]
+    log.debug "childSetColor($dni), name = ${name}, color = ${value}"
+    sendEthernet("${name} ${value}")
+}
+
 void childRelayOn(String dni) {
     def name = dni.split("-")[-1]
     log.debug "childRelayOn($dni), name = ${name}"
@@ -350,7 +356,10 @@ private void createChildDevice(String deviceName, String deviceNumber) {
          		case "relaySwitch": 
                 	deviceHandlerName = "Child Relay Switch" 
                 	break
-				case "temperature": 
+			case "rgbSwitch":
+			deviceHandlerName = "Child RGB Switch"
+			break
+			case "temperature": 
                 	deviceHandlerName = "Child Temperature Sensor" 
                 	break
          		case "humidity": 
@@ -368,7 +377,7 @@ private void createChildDevice(String deviceName, String deviceNumber) {
          		case "illuminancergb": 
                 	deviceHandlerName = "Child IlluminanceRGB Sensor" 
                 	break
-				case "voltage": 
+			case "voltage": 
                 	deviceHandlerName = "Child Voltage Sensor" 
                 	break
 				case "smoke": 


### PR DESCRIPTION
Add option for a child RGB switch to allow using this library for analog RGB LED's and strips.  Still working on the low level device but got the device handler working and attempting to send data back to its parent (HEX value).

