### PR TITLE
Update parent-st-anything-ethernet.groovy

### DIFF
--- a/devicetypes/ogiewon/parent-st-anything-ethernet.src/parent-st-anything-ethernet.groovy
+++ b/devicetypes/ogiewon/parent-st-anything-ethernet.src/parent-st-anything-ethernet.groovy
@@ -42,7 +42,7 @@ metadata {
 		input "ip", "text", title: "Arduino IP Address", description: "IP Address in form 192.168.1.226", required: true, displayDuringSetup: true
 		input "port", "text", title: "Arduino Port", description: "port in form of 8090", required: true, displayDuringSetup: true
 		input "mac", "text", title: "Arduino MAC Addr", description: "MAC Address in form of 02A1B2C3D4E5", required: true, displayDuringSetup: true
-		input "numButtons", "number", title: "Number of Buttons", description: "Number of Buttons to be implemented", defaultValue: 0, required: true, displayDuringSetup: true
+		input "numButtons", "number", title: "Number of Buttons", description: "Number of Buttons to be implemented", required: true, displayDuringSetup: true
 	}
 
 	// Tile Definitions


### PR DESCRIPTION
Think the biggest issue I and others have had is when first configuring the parent and not using any buttons is errors about it being required.  The only solution I have seen is to make it 1, or anything other then 0, save it, then go back and change it to 0.  I think based on testing this is because of the default value: 0 part not fully working (on SmartThings side).  So I'm suggesting keeping it as required but removing the default value.  It should get around this issue.  It will still force the option to be set but it shouldn't give a error when its set to 0 the first time.