### PR TITLE
Create EX_RGB_Dim.h

### DIFF
--- a/Arduino/libraries/ST_Anything/EX_RGB_Dim.h
+++ b/Arduino/libraries/ST_Anything/EX_RGB_Dim.h
@@ -46,7 +46,7 @@ namespace st
 			byte m_nChannelR;	//PWM Channel used for Red output
 			byte m_nChannelG;	//PWM Channel used for Green output
 			byte m_nChannelB;	//PWM Channel used for Blue output
-			char m_nHEX;		//HEX value of color to set
+			char m_nHEX;		//HEX value of color currently set
 
 			void writePWMToPins();	//function to update the Arduino PWM Output Pins
 
@@ -60,7 +60,7 @@ namespace st
 			//initialization routine
 			virtual void init();
 
-			//SmartThings Shield data handler (receives HEX values for writting to the outputs.  Turns on and off based on HEX (00000 = off, otherwise on))
+			//SmartThings Shield data handler (receives command to turn "on" or "off" the switch along with HEX value for LEDs)
 			virtual void beSmart(const String &str);
 			
 			//called periodically to ensure state of the switch is up to date in the SmartThings Cloud (in case an event is missed)

--- a/Arduino/libraries/ST_Anything/EX_RGB_Dim.h
+++ b/Arduino/libraries/ST_Anything/EX_RGB_Dim.h
@@ -53,7 +53,7 @@ namespace st
 
 		public:
 			//constructor - called in your sketch's global variable declaration section
-			EX_RGB_Dim(const __FlashStringHelper *name, byte PinR, byte PinG, byte PinB, bool CommonAnode, byte ChannelR, byte ChannelG, byte ChannelB);
+			EX_RGB_Dim(const __FlashStringHelper *name, byte PinR, byte PinG, byte PinB, bool CommonAnode, byte ChannelR = 0, byte ChannelG = 0, byte ChannelB = 0);
 			
 			//destructor
 			virtual ~EX_RGB_Dim();

--- a/Arduino/libraries/ST_Anything/EX_RGB_Dim.h
+++ b/Arduino/libraries/ST_Anything/EX_RGB_Dim.h
@@ -48,7 +48,6 @@ namespace st
 			byte m_nChannelB;	//PWM Channel used for Blue output
 			char m_nHEX;		//HEX value of color currently set
 			
-			void writeStatetoDevice(); //function to update the devices status
 			void writeRGBToPins();	//function to update the Arduino PWM Output Pins for RGB
 
 		public:

--- a/Arduino/libraries/ST_Anything/EX_RGB_Dim.h
+++ b/Arduino/libraries/ST_Anything/EX_RGB_Dim.h
@@ -47,7 +47,8 @@ namespace st
 			byte m_nChannelG;	//PWM Channel used for Green output
 			byte m_nChannelB;	//PWM Channel used for Blue output
 			char m_nHEX;		//HEX value of color currently set
-
+			
+			void writeStatetoDevice(); //function to update the devices status
 			void writePWMToPins();	//function to update the Arduino PWM Output Pins
 
 		public:

--- a/Arduino/libraries/ST_Anything/EX_RGB_Dim.h
+++ b/Arduino/libraries/ST_Anything/EX_RGB_Dim.h
@@ -49,7 +49,7 @@ namespace st
 			char m_nHEX;		//HEX value of color currently set
 			
 			void writeStatetoDevice(); //function to update the devices status
-			void writePWMToPins();	//function to update the Arduino PWM Output Pins
+			void writeRGBToPins();	//function to update the Arduino PWM Output Pins for RGB
 
 		public:
 			//constructor - called in your sketch's global variable declaration section

--- a/Arduino/libraries/ST_Anything/EX_RGB_Dim.h
+++ b/Arduino/libraries/ST_Anything/EX_RGB_Dim.h
@@ -77,7 +77,8 @@ namespace st
 			virtual byte getBlueChannel() const { return m_nChannelB; }
 
 			virtual bool getStatus() const { return m_bCurrentState; } //whether the switch is HIGH or LOW
-
+			virtual char getHEX() const { return m_nHEX; }	// color value in HEX
+			
 			//sets
 			virtual void setRedPin(byte pin);
 			virtual void setGreenPin(byte pin);

--- a/Arduino/libraries/ST_Anything/EX_RGB_Dim.h
+++ b/Arduino/libraries/ST_Anything/EX_RGB_Dim.h
@@ -1,0 +1,94 @@
+//******************************************************************************************
+//  File: EX_RGB_Dim.h
+//  Authors: Allan (vseven) based on EX_Switch_Dim by Dan G Ogorchock
+//
+//  Summary:  EX_RGB_Dim is a class which implements the SmartThings "Color Control", "Switch", and "Switch Level" device capabilities.
+//			  It inherits from the st::Executor class.
+//
+//			  Create an instance of this class in your sketch's global variable section
+//			  For Example:  st::EX_RGB_Dim executor1("rgbSwitch1", PIN_R, PIN_G, PIN_B, true, 0, 1, 2);
+//
+//			  st::EX_RGB_Dim() constructor requires the following arguments
+//				- String &name - REQUIRED - the name of the object - must match the Groovy ST_Anything DeviceType tile name
+//				- byte pin_r - REQUIRED - the Arduino Pin to be used as a digital output for Red
+//				- byte pin_g - REQUIRED - the Arduino Pin to be used as a digital output for Green
+//				- byte pin_b - REQUIRED - the Arduino Pin to be used as a digital output for Blue
+//				- bool commonAnode - REQUIRED - determines whether the LED uses a common Anode or Cathode.  True for Anode.
+//				- byte channel_r - OPTIONAL - PWM channel used for Red on a ESP32
+//				- byte channel_g - OPTIONAL - PWM channel used for Green on a ESP32
+//				- byte channel_b - OPTIONAL - PWM channel used for Blue on a ESP32
+//
+//  Change History:
+//
+//    Date        Who            What
+//    ----        ---            ----
+//    2016-04-30  Dan Ogorchock  Original Creation
+//    2018-08-14  Dan Ogorchock  Modified to avoid compiler errors on ESP32 since it currently does not support "analogWrite()"
+//    2017-08-30  Dan Ogorchock  Modified comment section above to comply with new Parent/Child Device Handler requirements
+//    2017-10-06  Allan (vseven) Modified original code from EX_Switch_Dim to be used for RGB lighting
+//
+//******************************************************************************************
+#ifndef ST_EX_RGB_DIM
+#define ST_EX_RGB_DIM
+
+#include "Executor.h"
+
+namespace st
+{
+	class EX_RGB_Dim: public Executor
+	{
+		private:
+			bool m_bCurrentState;	//HIGH or LOW
+			bool m_bCommonAnode;	//TRUE or FALSE
+			byte m_nPinR;		//Arduino Pin used as a PWM Output for Red
+			byte m_nPinG;		//Arduino Pin used as a PWM Output for Green
+			byte m_nPinB;		//Arduino Pin used as a PWM Output for Blue
+			byte m_nChannelR;	//PWM Channel used for Red output
+			byte m_nChannelG;	//PWM Channel used for Green output
+			byte m_nChannelB;	//PWM Channel used for Blue output
+			char m_nHEX;		//HEX value of color to set
+
+			void writePWMToPins();	//function to update the Arduino PWM Output Pins
+
+		public:
+			//constructor - called in your sketch's global variable declaration section
+			EX_RGB_Dim(const __FlashStringHelper *name, byte PinR, byte PinG, byte PinB, bool CommonAnode, byte ChannelR, byte ChannelG, byte ChannelB);
+			
+			//destructor
+			virtual ~EX_RGB_Dim();
+
+			//initialization routine
+			virtual void init();
+
+			//SmartThings Shield data handler (receives HEX values for writting to the outputs.  Turns on and off based on HEX (00000 = off, otherwise on))
+			virtual void beSmart(const String &str);
+			
+			//called periodically to ensure state of the switch is up to date in the SmartThings Cloud (in case an event is missed)
+			virtual void refresh();
+			
+			//gets
+			virtual byte getRedPin() const { return m_nPinR; }
+			virtual byte getGreenPin() const { return m_nPinG; }
+			virtual byte getBluePin() const { return m_nPinB; }
+
+			virtual byte getRedChannel() const { return m_nChannelR; }
+			virtual byte getGreenChannel() const { return m_nChannelG; }
+			virtual byte getBlueChannel() const { return m_nChannelB; }
+
+			virtual bool getStatus() const { return m_bCurrentState; } //whether the switch is HIGH or LOW
+
+			virtual char getHEX() const { return m_nHEX; }	// color value in HEX
+
+			//sets
+			virtual void setRedPin(byte pin);
+			virtual void setGreenPin(byte pin);
+			virtual void setBluePin(byte pin);
+			virtual void setCommonAnode(bool pin);
+			virtual void setRedChannel(byte pin);
+			virtual void setGreenChannel(byte pin);
+			virtual void setBlueChannel(byte pin);
+		
+	};
+}
+
+#endif

--- a/Arduino/libraries/ST_Anything/EX_RGB_Dim.h
+++ b/Arduino/libraries/ST_Anything/EX_RGB_Dim.h
@@ -78,13 +78,11 @@ namespace st
 
 			virtual bool getStatus() const { return m_bCurrentState; } //whether the switch is HIGH or LOW
 
-			virtual char getHEX() const { return m_nHEX; }	// color value in HEX
-
 			//sets
 			virtual void setRedPin(byte pin);
 			virtual void setGreenPin(byte pin);
 			virtual void setBluePin(byte pin);
-			virtual void setCommonAnode(bool pin);
+			
 			virtual void setRedChannel(byte pin);
 			virtual void setGreenChannel(byte pin);
 			virtual void setBlueChannel(byte pin);

--- a/Arduino/libraries/ST_Anything/EX_RGB_Dim.h
+++ b/Arduino/libraries/ST_Anything/EX_RGB_Dim.h
@@ -9,14 +9,14 @@
 //			  For Example:  st::EX_RGB_Dim executor1("rgbSwitch1", PIN_R, PIN_G, PIN_B, true, 0, 1, 2);
 //
 //			  st::EX_RGB_Dim() constructor requires the following arguments
-//				- String &name - REQUIRED - the name of the object - must match the Groovy ST_Anything DeviceType tile name
-//				- byte pin_r - REQUIRED - the Arduino Pin to be used as a digital output for Red
-//				- byte pin_g - REQUIRED - the Arduino Pin to be used as a digital output for Green
-//				- byte pin_b - REQUIRED - the Arduino Pin to be used as a digital output for Blue
+//				- String &name - REQUIRED - the name of the object - must match the Groovy ST_Anything DeviceType tile name.
+//				- byte pin_r - REQUIRED - the Arduino Pin to be used as a digital output for Red.
+//				- byte pin_g - REQUIRED - the Arduino Pin to be used as a digital output for Green.
+//				- byte pin_b - REQUIRED - the Arduino Pin to be used as a digital output for Blue.
 //				- bool commonAnode - REQUIRED - determines whether the LED uses a common Anode or Cathode.  True for Anode.
-//				- byte channel_r - OPTIONAL - PWM channel used for Red on a ESP32
-//				- byte channel_g - OPTIONAL - PWM channel used for Green on a ESP32
-//				- byte channel_b - OPTIONAL - PWM channel used for Blue on a ESP32
+//				- byte channel_r - OPTIONAL - PWM channel used for Red on a ESP32.
+//				- byte channel_g - OPTIONAL - PWM channel used for Green on a ESP32.
+//				- byte channel_b - OPTIONAL - PWM channel used for Blue on a ESP32.
 //
 //  Change History:
 //
@@ -46,13 +46,13 @@ namespace st
 			byte m_nChannelR;	//PWM Channel used for Red output
 			byte m_nChannelG;	//PWM Channel used for Green output
 			byte m_nChannelB;	//PWM Channel used for Blue output
-			char m_nHEX;		//HEX value of color currently set
-			
-			void writeRGBToPins();	//function to update the Arduino PWM Output Pins for RGB
+			String m_sCurrentHEX;	//HEX value of color currently set
+
+			void writeRGBToPins();	//function to update the Arduino PWM Output Pins
 
 		public:
 			//constructor - called in your sketch's global variable declaration section
-			EX_RGB_Dim(const __FlashStringHelper *name, byte PinR, byte PinG, byte PinB, bool CommonAnode, byte ChannelR = 0, byte ChannelG = 0, byte ChannelB = 0);
+			EX_RGB_Dim(const __FlashStringHelper *name, byte pinR, byte pinG, byte pinB, bool commonAnode, byte channelR = 0, byte channelG = 0, byte channelB = 0);
 			
 			//destructor
 			virtual ~EX_RGB_Dim();
@@ -76,16 +76,12 @@ namespace st
 			virtual byte getBlueChannel() const { return m_nChannelB; }
 
 			virtual bool getStatus() const { return m_bCurrentState; } //whether the switch is HIGH or LOW
-			virtual char getHEX() const { return m_nHEX; }	// color value in HEX
-			
+			virtual String getHEX() const { return m_sCurrentHEX; }	// color value in HEX
+
 			//sets
-			virtual void setRedPin(byte pin);
-			virtual void setGreenPin(byte pin);
-			virtual void setBluePin(byte pin);
-			
-			virtual void setRedChannel(byte pin);
-			virtual void setGreenChannel(byte pin);
-			virtual void setBlueChannel(byte pin);
+			virtual void setRedPin(byte pin,byte channel);
+			virtual void setGreenPin(byte pin,byte channel);
+			virtual void setBluePin(byte pin,byte channel);
 		
 	};
 }


### PR DESCRIPTION
This is my first attempt at doing this (other then the Adafruit color detector which was really jsut cut and paste).  I'm attempt to make the library universal for both a regular Arduino/ESP8266 and the ESP32 which uses a LedC library and PWM channels.  The idea would be the device sets the 3 pins (R,G,B) and for a ESP32 also the 3 channels (R,G,B).  There is also a commonAnode boolean that can be flipped depending on the LED you are using.  I.e. this could be used for a stand alone RGB LED or RGB LED strips with common anode or cathode.

The only two things passed to it would be On/Off and HEX of the color (standard #FFFFFF format).  Once its working the code could be modified into a RGBW with only the addition of another pin and channel since you can send the HEX as #FFFFFFFF.  

Please look this over and see if it makes sense and fits in with other libraries. I used the EX_Switch_Dim as the base since that made the most sense.  If this is incorrect please let me know what to change or tweak it.  Like I'm not sure on the "sets" section if you would just have a "setRGBPins" that takes all three pins as inputs, sane with the channels.  Once its "correct" I'll see if I can figure out the actual code (no use doing that if this parts not right).  I have it in Arduino already and it works great....just have to figure out how to convert it.

Oh and here is what I think would be the config from the sketch file:

 //Executors
  static st::EX_RGB_Dim         executor1(F("rgbSwitch1"), PIN_RGB1_Red, PIN_RGB1_Green, PIN_RGB1_Blue, true, 0, 1, 2);