### PR TITLE
changed Wifi setup to better handle static IP

### DIFF
--- a/Arduino/libraries/SmartThingsESP8266WiFi/SmartThingsESP8266WiFi.cpp
+++ b/Arduino/libraries/SmartThingsESP8266WiFi/SmartThingsESP8266WiFi.cpp
@@ -66,6 +66,11 @@ namespace st
 
 			// attempt to connect to WiFi network
 			WiFi.begin(st_ssid, st_password);
+			if (st_DHCP == false)
+			{
+				WiFi.config(st_localIP, st_localGateway, st_localSubnetMask, st_localDNSServer);
+			}
+
 			Serial.print(F("Attempting to connect to WPA SSID: "));
 			Serial.println(st_ssid);
 		}
@@ -77,10 +82,6 @@ namespace st
 
 		Serial.println();
 
-		if (st_DHCP == false)
-		{
-			WiFi.config(st_localIP, st_localGateway, st_localSubnetMask, st_localDNSServer);
-		}
 
 		st_server.begin();
 


### PR DESCRIPTION
I noticed in your SmartThingsESP8266WiFi::init() routine, the the WiFi.config() wasn't being done until after the WiFi connected.   With WiFi.begin() not immediately followed by the WiFi.config() will first connect via DHCP and obtain a dynmic IP, and then re-assign the static IP config.  While debugging things this morning, I noticed if I did "arp -a" I would see two IP addresses assigned my ESP8266's MAC - one from my dynamic pool, and the static one in the Arduino code).  I believe this was confusing one of my home switches.... I think??  Not sure, but if it matters,  this change I'm proposing should keep that from happening and should straight-away get a static IP.