### PR TITLE
Update child-contact-sensor.groovy

### DIFF
--- a/devicetypes/ogiewon/child-contact-sensor.src/child-contact-sensor.groovy
+++ b/devicetypes/ogiewon/child-contact-sensor.src/child-contact-sensor.groovy
@@ -19,11 +19,12 @@
  *    2017-04-10  Dan Ogorchock  Original Creation
  *    2017-08-23  Allan (vseven) Added a generateEvent routine that gets info from the parent device.  This routine runs each time the value is updated which can lead to other modifications of the device.
  *    2018-06-02  Dan Ogorchock  Revised/Simplified for Hubitat Composite Driver Model
+ *    2018-09-25  Allan (vseven) Added metadata for new SmartThings app
  *
  * 
  */
 metadata {
-	definition (name: "Child Contact Sensor", namespace: "ogiewon", author: "Dan Ogorchock") {
+	definition (name: "Child Contact Sensor", namespace: "ogiewon", author: "Dan Ogorchock", mnmn: "SmartThings", vid: "generic-contact") {
 		capability "Contact Sensor"
 		capability "Sensor"
 


### PR DESCRIPTION
This small change should allow the contact sensor to properly display in the new SmartThings app.  

It may not at first but if you change a devices type to something else then back to this it should properly report.  The same will need to be done to all other DTH's but this is a proof of concept test.  It did work on my modified contact DTH's although the extra stuff (different labels, etc) didn't carry through.  But at least they displayed.