### PR TITLE
Update child-temperature-sensor.groovy

### DIFF
--- a/devicetypes/ogiewon/child-temperature-sensor.src/child-temperature-sensor.groovy
+++ b/devicetypes/ogiewon/child-temperature-sensor.src/child-temperature-sensor.groovy
@@ -24,7 +24,7 @@
  * 
  */
 metadata {
-	definition (name: "Child Temperature Sensor", namespace: "ogiewon", author: "Daniel Ogorchock") {
+	definition (name: "Child Temperature Sensor", namespace: "ogiewon", author: "Daniel Ogorchock", mnmn: "SmartThings", vid: "generic-humidity") {
 		capability "Temperature Measurement"
 		capability "Sensor"
 


### PR DESCRIPTION
Added metadata for new SmartThings app.  No idea why there isn't a generic-temperature but the humidity one allows this DTH to work.