### PR TITLE
Updated for 1.1.6.114

### DIFF
--- a/HubDuino/Drivers/child-dimmer-switch.groovy
+++ b/HubDuino/Drivers/child-dimmer-switch.groovy
@@ -71,7 +71,7 @@ def off() {
 	sendData("off")
 }
 
-def setLevel(value) {
+def setLevel(value,duration=null) {
 	log.debug "setLevel >> value: $value"
 	def valueaux = value as Integer
 	def level = Math.max(Math.min(valueaux, 99), 0)

--- a/HubDuino/Drivers/child-servo.groovy
+++ b/HubDuino/Drivers/child-servo.groovy
@@ -53,7 +53,7 @@ metadata {
 }
 
 
-def setLevel(value) {
+def setLevel(value,duration=null) {
 	log.debug "setLevel >> value: $value"
 	def valueaux = value as Integer
 	def level = Math.max(Math.min(valueaux, 99), 0)


### PR DESCRIPTION
Updated to include "duration=null" for set level events as required by the new "scenes" implementation.  Otherwise, the scene won't execute correctly.  These were the only two drivers I could think of that would have this.