### PR TITLE
Update child-rgb-switch.groovy

### DIFF
--- a/devicetypes/ogiewon/child-rgb-switch.src/child-rgb-switch.groovy
+++ b/devicetypes/ogiewon/child-rgb-switch.src/child-rgb-switch.groovy
@@ -24,7 +24,7 @@
 
 // for the UI
 metadata {
-	definition (name: "Child RGB Switch", namespace: "ogiewon", author: "Allan (vseven) - based on code by Dan Ogorchock") {
+	definition (name: "Child RGB Switch", namespace: "ogiewon", author: "Allan (vseven) - based on code by Dan Ogorchock", ocfDeviceType: "oic.d.light", mnmn: "SmartThings", vid: "generic-rgbw-color-bulb) {
 	capability "Switch"		
 	capability "Switch Level"
 	capability "Actuator"


### PR DESCRIPTION
added meta data for "new" app to work.  There doesn't appear to be a rgb vid so used rgbw which seems to work.