### PR TITLE
Update child-rgbw-switch.groovy

### DIFF
--- a/devicetypes/ogiewon/child-rgbw-switch.src/child-rgbw-switch.groovy
+++ b/devicetypes/ogiewon/child-rgbw-switch.src/child-rgbw-switch.groovy
@@ -184,7 +184,8 @@ def setLevel(value) {
     sendEvent(name: "level", value: level)
 	
     // Turn on or off based on level selection
-    if (level == 0) { 
+    // Only if both RGB and W levels are 0 switch off
+    if (level == 0 && device.latestValue("whiteLevel") == 0) { 
 	    off() 
     } else {
 	    if (device.latestValue("switch") == "off") { on() }
@@ -197,8 +198,16 @@ def setWhiteLevel(value) {
     //log.debug "setWhiteLevel: ${value}"
     value = Math.min(value as Integer, 100)
     sendEvent(name: "whiteLevel", value: value)
+	
+    // Only if both RGB and W levels are 0 switch off 
+    if (whiteLevel == 0 && device.latestValue("level") == 0) { 
+    	off() 
+    } else {
+    	// whiteLevel >0 so switch on if not already
+    	if (device.latestValue("switch") == "off") { on() }
     def lastColor = device.latestValue("color")
 	adjustColor(lastColor)
+   }
 }
 
 void checkOnOff() {


### PR DESCRIPTION
Fixes 2 usability issues.
1) When setting the RGB level to zero, the switch would be turned off even with White level >0
2) With the switch off, setting the White level>0 would not turn it on.
The RGB and White levels now work independently.

With the RGB and White levels both >0, setting the RGB level to zero will not turn off the White light.
With the switch off, setting the White level now turns on the switch.

I have tested this change with an RGBW LED light strip and a NodeMCU and works perfectly.