### PR TITLE
Update child-rgb-switch.groovy

### DIFF
--- a/devicetypes/ogiewon/child-rgb-switch.src/child-rgb-switch.groovy
+++ b/devicetypes/ogiewon/child-rgb-switch.src/child-rgb-switch.groovy
@@ -142,25 +142,34 @@ def off() {
     sendData("off")
 }
 
-def setColor(Map color) {
-    log.debug "raw color map passed in: ${color}"
+def setColor(value) {
+    log.debug "setColor: ${value}"
     // Turn off the hard color tiles
     toggleTiles("off") 
     // If the color picker was selected we will have Red, Green, Blue, HEX, Hue, Saturation, and Alpha all present.
     // Any other control will most likely only have Hue and Saturation
-    if (color.hex){
+    if (value.hex){
         // came from the color picker.  Since the color selector takes into account lightness we have to reconvert
         // the color values and adjust the level slider to better represent where it should be at based on the color picked
-        def colorHSL = rgbToHSL(color)
+        def colorHSL = rgbToHSL(value)
         //log.debug "colorHSL: $colorHSL"
         sendEvent(name: "level", value: (colorHSL.l * 100))
-        adjustColor(color.hex)
-    } else if (color.hue && color.saturation) {
+    } else if (value.hue && value.saturation) {
         // came from the ST cloud which only contains hue and saturation.  So convert to hex and pass it.
-        def colorRGB = hslToRGB(color.hue, color.saturation, 0.5)
-        def colorHEX = rgbToHex(colorRGB)
-        adjustColor(colorHEX)
+	def rgb = colorUtil.hslToRgb(value.hue / 100, value.saturation / 100, 0.5)
+	rgb = rgb.collect{Math.round(it) as int}
+	value.hex = colorUtil.rgbToHex(*rgb)
     }
+    if(value.hue) {
+	sendEvent(name: "hue", value: value.hue, displayed: false)
+    }
+    if(value.saturation) {
+	sendEvent(name: "saturation", value: value.saturation, displayed: false)
+    }
+    if(value.hex?.trim()) {
+	sendEvent(name: "color", value: value.hex, displayed: false)
+    } 
+    adjustColor(value.hex)
 }
 
 def setLevel(value) {
@@ -270,7 +279,7 @@ def rgbToHex(rgb) {
 }
 
 def rgbToHSL(color) {
-	def r = color.red / 255
+    def r = color.red / 255
     def g = color.green / 255
     def b = color.blue / 255
     def h = 0
@@ -305,49 +314,6 @@ def rgbToHSL(color) {
     hsl = [h: h * 100, s: s * 100, l: l]
 
     hsl
-}
-
-def hslToRGB(float var_h, float var_s, float var_l) {
-	float h = var_h / 100
-    float s = var_s / 100
-    float l = var_l
-
-    def r = 0
-    def g = 0
-    def b = 0
-
-	if (s == 0) {
-    	r = l * 255
-        g = l * 255
-        b = l * 255
-	} else {
-    	float var_2 = 0
-    	if (l < 0.5) {
-        	var_2 = l * (1 + s)
-        } else {
-        	var_2 = (l + s) - (s * l)
-        }
-
-        float var_1 = 2 * l - var_2
-
-        r = 255 * hueToRgb(var_1, var_2, h + (1 / 3))
-        g = 255 * hueToRgb(var_1, var_2, h)
-        b = 255 * hueToRgb(var_1, var_2, h - (1 / 3))
-    }
-
-    def rgb = [:]
-    rgb = [red: Math.round(r), green: Math.round(g), blue: Math.round(b)]
-
-    rgb
-}
-
-def hueToRgb(v1, v2, vh) {
-	if (vh < 0) { vh += 1 }
-	if (vh > 1) { vh -= 1 }
-	if ((6 * vh) < 1) { return (v1 + (v2 - v1) * 6 * vh) }
-    if ((2 * vh) < 1) { return (v2) }
-    if ((3 * vh) < 2) { return (v1 + (v2 - $v1) * ((2 / 3 - vh) * 6)) }
-    return (v1)
 }
 
 def colorNameToRgb(color) {


### PR DESCRIPTION
Switched the HSL to RGB function from the internal one, which got buggy with commands from amazon, to use the color utilities provided by SmartThings.  Removed the no longer needed internal functions.  Updated the setColor routine to be more in line with standards (https://github.com/SmartThingsCommunity/SmartThingsPublic/blob/master/devicetypes/smartthings/fibaro-rgbw-controller.src/fibaro-rgbw-controller.groovy for example).

Same will need to be done for RGBW eventually.