### PR TITLE
Create ST_Anything_Sleepy_ESP32WiFi.ino

### DIFF
--- a/Arduino/Sketches/ST_Anything_Sleepy_ESP32WiFi/ST_Anything_Sleepy_ESP32WiFi.ino
+++ b/Arduino/Sketches/ST_Anything_Sleepy_ESP32WiFi/ST_Anything_Sleepy_ESP32WiFi.ino
@@ -1,0 +1,330 @@
+//******************************************************************************************
+//  File: ST_Anything_Sleepy_ESP32WiFi.ino
+//  Authors: Dan G Ogorchock & Daniel J Ogorchock (Father and Son)
+//
+//  Summary:  This Arduino Sketch, along with the ST_Anything library and the revised SmartThings 
+//            library, demonstrates the ability of a ESP32 to implement Deep Sleep so it
+//            can be used with battery power like a standard wireless sensor.
+//            The ST_Anything library takes care of all of the work to schedule device updates
+//            as well as all communications with the ESP32's WiFi.
+//
+//            ST_Anything_Sleepy_ESP32WiFi implements the following ST Capabilities as a demo of what is possible with a single ESP32
+//              - 1 x Voltage Measurement device (used to feedback the battery status)
+//              - 1 x Temperature Measurement device (Temperature from DHT22 device)
+//              - 1 x Humidity Measurement device (Humidity from DHT22 device)
+//    
+//  Change History:
+//
+//    Date        Who            What
+//    ----        ---            ----
+//    2017-08-14  Dan Ogorchock  Original Creation - Adapted from ESP8266 to work with ESP32 board
+//    2018-02-09  Dan Ogorchock  Added support for Hubitat Elevation Hub
+//    2020-08-06  Allan (vseven) Added support for BlueTooth logging
+//    2020-08-10  Allan (vseven) Added support for deep sleep on the ESP32
+//
+//   Special thanks to Joshua Spain for his contributions in porting ST_Anything to the ESP32!
+//
+//******************************************************************************************
+//******************************************************************************************
+// SmartThings Library for ESP32WiFi
+//******************************************************************************************
+#include <SmartThingsESP32WiFi.h>
+
+//******************************************************************************************
+// ST_Anything Library 
+//******************************************************************************************
+#include <Constants.h>       //Constants.h is designed to be modified by the end user to adjust behavior of the ST_Anything library
+#include <Device.h>          //Generic Device Class, inherited by Sensor and Executor classes
+#include <Sensor.h>          //Generic Sensor Class, typically provides data to ST Cloud (e.g. Temperature, Motion, etc...)
+#include <Executor.h>        //Generic Executor Class, typically receives data from ST Cloud (e.g. Switch)
+#include <InterruptSensor.h> //Generic Interrupt "Sensor" Class, waits for change of state on digital input 
+#include <PollingSensor.h>   //Generic Polling "Sensor" Class, polls Arduino pins periodically
+#include <Everything.h>      //Master Brain of ST_Anything library that ties everything together and performs ST Shield communications
+
+#include <PS_DS18B20_Temperature.h>  //Implements a Polling Sesnor (PS) to measure Temperature via DS18B20 libraries 
+#include <PS_Illuminance.h>  //Implements a Polling Sensor (PS) to measure light levels via a photo resistor on an analog input pin 
+#include <PS_Voltage.h>      //Implements a Polling Sensor (PS) to measure voltage on an analog input pin 
+#include <PS_TemperatureHumidity.h>  //Implements a Polling Sensor (PS) to measure Temperature and Humidity via DHT library
+#include <PS_Water.h>        //Implements a Polling Sensor (PS) to measure presence of water (i.e. leak detector) on an analog input pin 
+#include <PS_MQ2_Smoke.h>    //Implements an Polling Sensor (PS) to monitor the status of an analog input pin from a MQ2 sensor
+#include <IS_Motion.h>       //Implements an Interrupt Sensor (IS) to detect motion via a PIR sensor on a digital input pin
+#include <IS_Contact.h>      //Implements an Interrupt Sensor (IS) to monitor the status of a digital input pin
+#include <IS_Smoke.h>        //Implements an Interrupt Sensor (IS) to monitor the status of a digital input pin
+#include <IS_CarbonMonoxide.h> //Implements an Interrupt Sensor (IS) to monitor the status of a digital input pin
+#include <IS_DoorControl.h>  //Implements an Interrupt Sensor (IS) and Executor to monitor the status of a digital input pin and control a digital output pin
+#include <IS_Button.h>       //Implements an Interrupt Sensor (IS) to monitor the status of a digital input pin for button presses
+#include <EX_Switch.h>       //Implements an Executor (EX) via a digital output to a relay
+#include <EX_Alarm.h>        //Implements Executor (EX)as an Alarm capability with Siren and Strobe via digital outputs to relays
+#include <S_TimedRelay.h>    //Implements a Sensor to control a digital output pin with timing/cycle repeat capabilities
+#include <EX_Switch_Dim.h>   //Implements an Executor (EX) for a switch (on/off) and pwm output (level) uses 2 digital output pins
+
+//******************************************************************************************
+// ESP32 BlueTooth serial monitor support.  Uncomment to use.
+// Note: Adding BT support may require a larger partition.  Do this under Tool -> Partition Scheme -> Huge APP
+//       You will also need a computer with BlueTooth support or a BlueTooth app on your smart phone such 
+//       as "Serial BlueTooth Terminal" (https://play.google.com/store/apps/details?id=de.kai_morich.serial_bluetooth_terminal&hl=en_US)
+//******************************************************************************************
+//#include <BluetoothSerial.h>  //Header File for Serial Bluetooth
+//#if !defined(CONFIG_BT_ENABLED) || !defined(CONFIG_BLUEDROID_ENABLED)
+//#error Bluetooth is not enabled! Please run `make menuconfig` to and enable it
+//#endif
+//BluetoothSerial SerialBT;     //Object for Bluetooth
+
+//****************************************************************************************************************************
+//NodeMCU-32s ESP32 Pin Definitions (just for reference from ..hardware\espressif\esp32\variants\nodemcu-32s\pins_arduino.h)
+//****************************************************************************************************************************
+//#define LED_BUILTIN 2
+//#define BUILTIN_LED 2
+//
+//#define A0 = 36;
+//#define A3 = 39;
+//#define A4 = 32;
+//#define A5 = 33;
+//#define A6 = 34;
+//#define A7 = 35;
+//#define A10 = 4;
+//#define A11 = 0;
+//#define A12 = 2;
+//#define A13 = 15;
+//#define A14 = 13;
+//#define A15 = 12;
+//#define A16 = 14;
+//#define A17 = 27;
+//#define A18 = 25;
+//#define A19 = 26;
+
+//******************************************************************************************
+//Define which Arduino Pins will be used for each device
+//******************************************************************************************
+//"RESERVED" pins for ESP32 - best to avoid
+#define PIN_0_RESERVED             0  //reserved ESP32 boot/program upload
+#define PIN_1_RESERVED             1  //reserved ESP32 for TX0
+#define PIN_3_RESERVED             3  //reserved ESP32 for RX0
+#define PIN_6_RESERVED             6  //reserved ESP32 for flash
+#define PIN_7_RESERVED             7  //reserved ESP32 for flash
+#define PIN_8_RESERVED             8  //reserved ESP32 for flash
+#define PIN_9_RESERVED             9  //reserved ESP32 for flash
+#define PIN_10_RESERVED           10  //reserved ESP32 for flash
+#define PIN_11_RESERVED           11  //reserved ESP32 for flash
+
+//Analog Pins
+#define PIN_VOLTAGE_1             A4  //(GPIO 32) SmartThings Capability "Voltage Measurement"
+
+//Digital Pins
+#define PIN_TEMPERATUREHUMIDITY_1 25  //SmartThings Capabilities "Temperature Measurement" and "Relative Humidity Measurement"
+
+//******************************************************************************************
+//Define some sleep settings.  
+//******************************************************************************************
+#define uS_TO_S_FACTOR 1000000    // Conversion factor for micro seconds to seconds
+#define TIME_TO_SLEEP  3600       // Time ESP32 will go to sleep (in seconds).  3600 = 1 hour.  Set higher for better 
+                                  // battery life, lower for more frequent updates.
+RTC_DATA_ATTR int bootCount = 0;  // Save the boot count to RC memory which will survive sleep.
+
+//******************************************************************************************
+//ESP832 WiFi Information
+//******************************************************************************************
+String str_ssid     = "YourSSIDHere";                           //  <---You must edit this line!
+String str_password = "YourPasswordHere";                   //  <---You must edit this line!
+IPAddress ip(192, 169, 1, 129);       //Device IP Address       //  <---You must edit this line!
+IPAddress gateway(192, 168, 1, 1);    //Router gateway          //  <---You must edit this line!
+IPAddress subnet(255, 255, 255, 0);   //LAN subnet mask         //  <---You must edit this line!
+IPAddress dnsserver(192, 168, 1, 1);  //DNS server              //  <---You must edit this line!
+const unsigned int serverPort = 8090; // port to run the http server on
+
+// Smartthings / Hubitat Hub TCP/IP Address
+IPAddress hubIp(192, 168, 1, 149);    // smartthings/hubitat hub ip //  <---You must edit this line!
+
+// SmartThings / Hubitat Hub TCP/IP Address: UNCOMMENT line that corresponds to your hub, COMMENT the other
+const unsigned int hubPort = 39500;   // smartthings hub port
+//const unsigned int hubPort = 39501;   // hubitat hub port
+
+//******************************************************************************************
+//st::Everything::callOnMsgSend() optional callback routine.  This is a sniffer to monitor 
+//    data being sent to ST.  This allows a user to act on data changes locally within the 
+//    Arduino sktech.
+//******************************************************************************************
+void callback(const String &msg)
+{
+//  String strTemp = msg;
+//  Serial.print(F("ST_Anything Callback: Sniffed data = "));
+//  Serial.println(msg);
+//  SerialBT.print(F("ST_Anything Callback: Sniffed data = "));  // BlueTooth monitoring
+//  SerialBT.println(msg);
+
+  //TODO:  Add local logic here to take action when a device's value/state is changed
+  
+  //Masquerade as the ThingShield to send data to the Arduino, as if from the ST Cloud (uncomment and edit following line)
+  //st::receiveSmartString("Put your command here!");  //use same strings that the Device Handler would send
+//  if (strTemp.startsWith("temperature1"))
+//  {
+//    strTemp.remove(0,13);
+//    Serial.println(strTemp);
+//  }
+//  if (strTemp.startsWith("humidity1"))
+//  {
+//    strTemp.remove(0,10);
+//    Serial.println(strTemp);
+//  }
+}
+
+//******************************************************************************************
+//Arduino Setup() routine
+//******************************************************************************************
+void setup()
+{
+  //******************************************************************************************
+  // Setup the default values for the ADC.  Used for analog voltage reads.
+  //  Notes:  analogReadResolution(12) sets the resolution for all pins. 12 = 0-4095, 11 = 0-2047, 10 = 0-1024, 9 = 0-512 
+  //          analogSetAttenuation(ADC_11db) sets the attenuation for all pins.  11db = 0-3.3v, 6dB range = 0-2.2v, 2.5db = 0-1.5v, 0db = 0-1v
+  //          analogSetPinAttenuation(A7, ADC_11db) sets the attenuation for individual pins.
+  //******************************************************************************************
+  
+  analogReadResolution(11);        // Default of 12 is not very linear.  Recommended to use 10 or 11 depending on needed resolution.
+  analogSetAttenuation(ADC_6db);   // Default is 11db which is very noisy.  Recommended to use 2.5 or 6.
+  
+  //******************************************************************************************
+  //Declare each Device that is attached to the Arduino
+  //  Notes: - For each device, there is typically a corresponding "tile" defined in your 
+  //           SmartThings Device Hanlder Groovy code, except when using new COMPOSITE Device Handler
+  //         - For details on each device's constructor arguments below, please refer to the 
+  //           corresponding header (.h) and program (.cpp) files.
+  //         - The name assigned to each device (1st argument below) must match the Groovy
+  //           Device Handler names.  (Note: "temphumid" below is the exception to this rule
+  //           as the DHT sensors produce both "temperature" and "humidity".  Data from that
+  //           particular sensor is sent to the ST Hub in two separate updates, one for 
+  //           "temperature" and one for "humidity")
+  //         - The new Composite Device Handler is comprised of a Parent DH and various Child
+  //           DH's.  The names used below MUST not be changed for the Automatic Creation of
+  //           child devices to work properly.  Simply increment the number by +1 for each duplicate
+  //           device (e.g. contact1, contact2, contact3, etc...)  You can rename the Child Devices
+  //           to match your specific use case in the ST Phone Application.
+  //******************************************************************************************
+  //Polling Sensors
+  static st::PS_Voltage             sensor1(F("voltage1"), 60, 40, PIN_VOLTAGE_1, 0, 4095, 0, 3300, 1, 100);
+  static st::PS_TemperatureHumidity sensor2(F("temphumid1"), 15, 5, PIN_TEMPERATUREHUMIDITY_1, st::PS_TemperatureHumidity::DHT22,"temperature1","humidity1");
+
+  //Interrupt Sensors 
+  
+  //Special sensors/executors (uses portions of both polling and executor classes)
+  
+  //Executors
+  
+  //*****************************************************************************
+  //  Configure debug print output from each main class 
+  //  -Note: Set these to "false" if using Hardware Serial on pins 0 & 1
+  //         to prevent communication conflicts with the ST Shield communications
+  //*****************************************************************************
+  st::Everything::debug=true;
+  st::Executor::debug=true;
+  st::Device::debug=true;
+  st::PollingSensor::debug=true;
+  st::InterruptSensor::debug=true;
+
+  //*****************************************************************************
+  //Initialize the "Everything" Class
+  //*****************************************************************************
+
+  //Initialize the optional local callback routine (safe to comment out if not desired)
+  st::Everything::callOnMsgSend = callback;
+  
+  //Create the SmartThings ESP32WiFi Communications Object
+    //STATIC IP Assignment - Recommended
+    st::Everything::SmartThing = new st::SmartThingsESP32WiFi(str_ssid, str_password, ip, gateway, subnet, dnsserver, serverPort, hubIp, hubPort, st::receiveSmartString);
+ 
+    //DHCP IP Assigment - Must set your router's DHCP server to provice a static IP address for this device's MAC address
+    //st::Everything::SmartThing = new st::SmartThingsESP32WiFi(str_ssid, str_password, serverPort, hubIp, hubPort, st::receiveSmartString);
+
+  //Run the Everything class' init() routine which establishes WiFi communications with SmartThings Hub
+  st::Everything::init();
+  
+  //*****************************************************************************
+  //Add each sensor to the "Everything" Class
+  //*****************************************************************************
+  st::Everything::addSensor(&sensor1);
+  st::Everything::addSensor(&sensor2);
+      
+  //*****************************************************************************
+  //Add each executor to the "Everything" Class
+  //*****************************************************************************
+
+  //*****************************************************************************
+  //Increment our boot count, find out why we booted up, then setup sleep
+  //*****************************************************************************
+  ++bootCount;
+  delay(500);
+  Serial.println("**************************************");
+  Serial.println("Boot number: " + String(bootCount));
+  print_wakeup_reason();
+  esp_sleep_enable_timer_wakeup(TIME_TO_SLEEP * uS_TO_S_FACTOR);
+  Serial.println("Setup ESP32 to sleep every " + String(TIME_TO_SLEEP) + " Seconds");
+  Serial.println("**************************************");
+  
+  //*****************************************************************************
+  //Initialize each of the devices which were added to the Everything Class
+  //*****************************************************************************
+  st::Everything::initDevices();
+
+  //*****************************************************************************
+  //Enable Bluetooth serial monitoring.  Uncomment to use.
+  //*****************************************************************************
+  //Serial.begin(115200);
+  //SerialBT.register_callback(callback);
+  //if(!SerialBT.begin("ESP32_ST_Anything")){  //Name of your Bluetooth Signal.  Use a unique name if you have multiple devices
+  //  Serial.println("An error occurred initializing Bluetooth");
+  //}else{
+  //  Serial.println("Bluetooth Device is Ready to Pair");
+  //}
+}
+
+//******************************************************************************************
+//Arduino Loop() routine
+//******************************************************************************************
+void loop()
+{
+  //*****************************************************************************
+  //Execute the Everything run method which takes care of "Everything"
+  //*****************************************************************************
+  st::Everything::run();
+
+  //*****************************************************************************
+  //Go to sleep
+  //*****************************************************************************
+  Serial.println("Going to sleep now");
+  delay(1000);
+  Serial.flush(); 
+  esp_deep_sleep_start();
+}
+
+// Callback routine for BlueTooth.  Uncomment to enable
+//void callback(esp_spp_cb_event_t event, esp_spp_cb_param_t *param){
+//  if(event == ESP_SPP_SRV_OPEN_EVT){
+//    Serial.println("Client Connected to BlueTooth!");
+//    Serial.print("Client address is: ");
+//     for (int i = 0; i < 6; i++) {
+//      Serial.printf("%02X", param->srv_open.rem_bda[i]);
+//      if (i < 6) {
+//        Serial.print(":");
+//      }
+//     }
+//  }
+//  if(event == ESP_SPP_CLOSE_EVT ){
+//    Serial.println("Client disconnected from BlueTooth");
+//  }
+// }
+
+void print_wakeup_reason(){
+  esp_sleep_wakeup_cause_t wakeup_reason;
+
+  wakeup_reason = esp_sleep_get_wakeup_cause();
+
+  switch(wakeup_reason)
+  {
+    case ESP_SLEEP_WAKEUP_EXT0 : Serial.println("Wakeup caused by external signal using RTC_IO"); break;
+    case ESP_SLEEP_WAKEUP_EXT1 : Serial.println("Wakeup caused by external signal using RTC_CNTL"); break;
+    case ESP_SLEEP_WAKEUP_TIMER : Serial.println("Wakeup caused by timer"); break;
+    case ESP_SLEEP_WAKEUP_TOUCHPAD : Serial.println("Wakeup caused by touchpad"); break;
+    case ESP_SLEEP_WAKEUP_ULP : Serial.println("Wakeup caused by ULP program"); break;
+    default : Serial.printf("Wakeup was not caused by deep sleep: %d\n",wakeup_reason); break;
+  }
+}


### PR DESCRIPTION
This is a example sketch based on "ST_Anything_Multiples_ESP32WiFi" that adds in both ESP32 BlueTooth monitoring and Deep Sleep (https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/system/sleep_modes.html) using a timer to auto wake up the controller.  Doing so, with other tweaks (removing power LED, infrequent wake up timer, etc) can result in a ESP32 lasting multiple months even over a year on a single LiPoly battery.

(Yes I realize BT monitoring is relatively pointless on a sleepy device but the code is already commented out and kept it in since that version was the latest and greatest.  I also think eventually there should be a single "ST_Anything_Multiples_ESP32WiFi" that has all this in it but commented out.)