### PR TITLE
Fix bug in DTH. New ST mobile app doesn't honor wildcard range

### DIFF
--- a/devicetypes/ogiewon/parent-st-anything-ethernet.src/parent-st-anything-ethernet.groovy
+++ b/devicetypes/ogiewon/parent-st-anything-ethernet.src/parent-st-anything-ethernet.groovy
@@ -71,7 +71,7 @@ metadata {
     	input "ip", "text", title: "Arduino IP Address", description: "IP Address in form 192.168.1.226", required: true, displayDuringSetup: true
 		input "port", "text", title: "Arduino Port", description: "port in form of 8090", required: true, displayDuringSetup: true
 		input "mac", "text", title: "Arduino MAC Addr", description: "MAC Address in form of 02A1B2C3D4E5", required: true, displayDuringSetup: true
-		input "timeOut", "number", title: "Timeout in Seconds", description: "Arduino max time (try 900)", range: "120..*", required: true, displayDuringSetup:true
+		input "timeOut", "number", title: "Timeout in Seconds", description: "Arduino max time (try 900)", range: "120..86400", required: true, displayDuringSetup:true
 	}
 
 	// Tile Definitions


### PR DESCRIPTION
The new ST mobile app doesn't appear to honor wildcard `range` values for the `input` definitions. After updating the parent DTH `range` attribute, the mobile app allowed me to enter/save a value. However, I'm not sure what the upper end of the range should be. I chose 86400, which is the number of seconds in a day.