### PR TITLE
Custom capabilities

### DIFF
--- a/devicetypes/ogiewon/parent-st-anything-ethernet.src/parent-st-anything-ethernet.groovy
+++ b/devicetypes/ogiewon/parent-st-anything-ethernet.src/parent-st-anything-ethernet.groovy
@@ -195,6 +195,7 @@ def sendEthernet(message) {
     }
 }
 
+// afterwatch06989.refresh capability -- command
 def refresh() {
 	log.debug "Executing 'refresh()'"
 	sendEthernet("refresh")

--- a/devicetypes/ogiewon/parent-st-anything-ethernet.src/parent-st-anything-ethernet.groovy
+++ b/devicetypes/ogiewon/parent-st-anything-ethernet.src/parent-st-anything-ethernet.groovy
@@ -195,7 +195,7 @@ def sendEthernet(message) {
     }
 }
 
-// afterwatch06989.refresh capability -- command
+// refresh capability command callback
 def refresh() {
 	log.debug "Executing 'refresh()'"
 	sendEthernet("refresh")

--- a/devicetypes/ogiewon/st-capabilities/README.md
+++ b/devicetypes/ogiewon/st-capabilities/README.md
@@ -1,0 +1,80 @@
+# Custom DTH for new ST app
+
+The new ST app utilizes a 4-part topology to construct a device's UI.
+
+```
+  +-----+    
+  | DTH |
+  +-----+    
+     |    +---------------+
+     +--> | Device Config |
+          +---------------+
+                  |    +-------------+     +---------------+
+                  +--> | Capability1 | --> | Presentation1 |
+                  |    +-------------+     +---------------+
+                  |    +-------------+     +---------------+
+                  +--> | Capability2 | --> | Presentation2 |
+                  |    +-------------+     +---------------+
+                  |
+                  ...
+```
+
+Starting from the bottom and working up...
+
+- The `Presentation` describes how the capability should be rendered when shown on the dashboard or detail views.
+- The `Capability` defines the attributes and commands available to the DHT and Device Config. _NOTE_: Only a single attribute per capability is currently recommended.
+- The `Device Config` manages the layout and presentation of all of the capabilities for the device. It defines which capability will be rendered on the dashboard and in which order the capabilities will be rendered in the detail view. _NOTE_: The `Device Config` describes **where** each capability will be displayed. The `Presentation` describes **how** a specific capability will be display.
+- The `DTH` provides the functions, handlers, and callbacks that interact with the ST APIs. It acts as the glue between the capabilities and the ST platform.
+
+## Capability
+
+```
+CAP_ID=afterwatch06989.whatever
+CAP_VERSION=1
+
+# create
+smartthings capabilities:create -j -i ./st-capability.json
+
+# update
+smartthings capabilities:update $CAP_ID $CAP_VERSION -j -i ./st-capability.json
+```
+
+## Capability Presentation
+
+```
+CAP_ID=afterwatch06989.whatever
+CAP_VERSION=1
+
+# create
+smartthings capabilities:presentation:create $CAP_ID $CAP_VERSION -j -i ./st-presentation.json
+
+# update
+smartthings capabilities:presentation:update $CAP_ID $CAP_VERSION -j -i ./st-presentation.json
+```
+
+## Device Config
+
+```
+DTH_UUID=aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee
+
+# generate
+smartthings presentation:device-config:generate $DTH_UUID --dth -j -o ./st-device-config.json
+
+# create
+smartthings presentation:device-config:create -j -i ./st-device-config.json
+```
+
+## Resources
+
+1. Good DTH overview for new ST app:
+    
+    see: https://community.smartthings.com/t/custom-capability-and-cli-developer-preview/197296/678
+
+2. Get VID of built-in device configs:
+
+    ```
+    curl --header "Authorization: Bearer AUTHTOKEN" https://api.smartthings.com/v1/presentation/deviceconfig?"presentationId=generic-switch&mnmn=SmartThings"
+    ```
+
+    see: https://community.smartthings.com/t/custom-capability-and-cli-developer-preview/197296/633
+

--- a/devicetypes/ogiewon/st-capabilities/last-updated/st-capability.json
+++ b/devicetypes/ogiewon/st-capabilities/last-updated/st-capability.json
@@ -1,0 +1,31 @@
+{
+    "id": "afterwatch06989.lastupdated",
+    "version": 1,
+    "status": "proposed",
+    "name": "LastUpdated",
+    "attributes": {
+        "lastUpdated": {
+            "schema": {
+                "type": "object",
+                "properties": {
+                    "value": {
+                        "type": "string"
+                    },
+                    "unit": {
+                        "type": "string",
+                        "enum": [
+                            "time"
+                        ],
+                        "default": "time"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "value"
+                ]
+            }
+        }
+    },
+    "commands": {
+    }
+}

--- a/devicetypes/ogiewon/st-capabilities/last-updated/st-presentation.json
+++ b/devicetypes/ogiewon/st-capabilities/last-updated/st-presentation.json
@@ -1,0 +1,23 @@
+{
+    "dashboard": {
+        "states": [
+            {
+                "label": "{{lastUpdated.value}} {{lastUpdated.unit}}"
+            }
+        ],
+        "actions": [],
+        "basicPlus": []        
+    },
+    "detailView": [
+        {
+            "label": "Last Updated",
+            "displayType": "state",
+            "state": {
+                "label": "{{lastUpdated.value}}",
+                "unit": "lastUpdated.unit"
+            }
+        }
+    ],
+    "id": "afterwatch06989.lastupdated",
+    "version": 1
+}

--- a/devicetypes/ogiewon/st-capabilities/refresh/st-capability.json
+++ b/devicetypes/ogiewon/st-capabilities/refresh/st-capability.json
@@ -1,0 +1,14 @@
+{
+    "id": "afterwatch06989.refresh",
+    "version": 1,
+    "status": "proposed",
+    "name": "Refresh",
+    "attributes": {
+    },
+    "commands": {
+        "refresh": {
+            "name": "refresh",
+            "arguments": []
+        }
+    }
+}

--- a/devicetypes/ogiewon/st-capabilities/refresh/st-presentation.json
+++ b/devicetypes/ogiewon/st-capabilities/refresh/st-presentation.json
@@ -1,0 +1,22 @@
+{
+    "dashboard": {
+        "states": [
+            {
+                "label": "Refresh"
+            }
+        ],
+        "actions": [],
+        "basicPlus": []        
+    },
+    "detailView": [
+        {
+            "label": "Refresh",
+            "displayType": "pushButton",
+            "pushButton": {
+                "command": "refresh"
+            }
+        }
+    ],
+    "id": "afterwatch06989.refresh",
+    "version": 1
+}

--- a/devicetypes/ogiewon/st-capabilities/ultrasonic/st-capability.json
+++ b/devicetypes/ogiewon/st-capabilities/ultrasonic/st-capability.json
@@ -1,0 +1,33 @@
+{
+    "id": "afterwatch06989.ultrasonic",
+    "version": 1,
+    "status": "proposed",
+    "name": "Ultrasonic",
+    "attributes": {
+        "ultrasonic": {
+            "schema": {
+                "type": "object",
+                "properties": {
+                    "value": {
+                        "type": "number",
+                        "minimum": 0,
+                        "maximum": 2000
+                    },
+                    "unit": {
+                        "type": "string",
+                        "enum": [
+                            "cm"
+                        ],
+                        "default": "cm"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "value"
+                ]
+            }
+        }
+    },
+    "commands": {
+    }
+}

--- a/devicetypes/ogiewon/st-capabilities/ultrasonic/st-presentation.json
+++ b/devicetypes/ogiewon/st-capabilities/ultrasonic/st-presentation.json
@@ -1,0 +1,23 @@
+{
+    "dashboard": {
+        "states": [
+            {
+                "label": "{{ultrasonic.value}} {{ultrasonic.unit}}"
+            }
+        ],
+        "actions": [],
+        "basicPlus": []        
+    },
+    "detailView": [
+        {
+            "label": "Ultrasonic",
+            "displayType": "state",
+            "state": {
+                "label": "{{ultrasonic.value}}",
+                "unit": "ultrasonic.unit"
+            }
+        }
+    ],
+    "id": "afterwatch06989.ultrasonic",
+    "version": 1
+}


### PR DESCRIPTION
This PR includes all the capability and presentation configs used to generate the afterwatch06989.xxxx (version 1) components that are referenced by the current master branch.

I've included a `README.md` file to help get folks started. I admit that the doc is pretty thin, especially around the ST CLI commands to publish capabilities and presentations. Since I published a v1 of the capabilities (afterwatch06989.xxxx) to the SmartThings cloud, the DTHs should work out-of-the-box for anyone. I will be careful to not change the published v1 capabilities, so other folks don't have to chew glass to get things working.

I feel that it is important to keep these assets with the DTHs. The new ST app makes the DTHs useless without the various capabilities assets being uploaded to the ST cloud. Essentially, the DTH has been demoted to logic only, where the layout is defined in the device-config.json and each capability handles its own rendering and validation.

