### PR TITLE
Fix compiler warning and stack corruption in Everything class

### DIFF
--- a/Arduino/libraries/ST_Anything/Everything.cpp
+++ b/Arduino/libraries/ST_Anything/Everything.cpp
@@ -265,7 +265,9 @@ namespace st
 
 	bool Everything::sendSmartStringNow(const String &str)
 	{
-		if (sendSmartString(str)) sendStrings(); //send any pending updates to ST Cloud immediately
+		bool queued = sendSmartString(str);
+		if (queued) sendStrings(); //send any pending updates to ST Cloud immediately
+		return queued;
 	}
 
 	Device* Everything::getDeviceByName(const String &str)


### PR DESCRIPTION
Everything::sendSmartStringNow had no return value despite one being declared, resulting in a compiler warning and stack corruption at runtime.