### PR TITLE
Support for MPR121

### DIFF
--- a/Arduino/libraries/Adafruit MPR121/Adafruit_MPR121.cpp
+++ b/Arduino/libraries/Adafruit MPR121/Adafruit_MPR121.cpp
@@ -1,0 +1,277 @@
+/*!
+ * @file Adafruit_MPR121.cpp
+ *
+ *  @mainpage Adafruit MPR121 arduino driver
+ *
+ *  @section intro_sec Introduction
+ *
+ *  This is a library for the MPR121 I2C 12-chan Capacitive Sensor
+ *
+ *  Designed specifically to work with the MPR121 sensor from Adafruit
+ *  ----> https://www.adafruit.com/products/1982
+ *
+ *  These sensors use I2C to communicate, 2+ pins are required to
+ *  interface
+ *
+ *  Adafruit invests time and resources providing this open source code,
+ *  please support Adafruit and open-source hardware by purchasing
+ *  products from Adafruit!
+ *
+ *  @section author Author
+ *
+ *  Written by Limor Fried/Ladyada for Adafruit Industries.
+ *
+ *  @section license License
+ *
+ *  BSD license, all text here must be included in any redistribution.
+ */
+
+#include "Adafruit_MPR121.h"
+
+// uncomment to use autoconfig !
+//#define AUTOCONFIG // use autoconfig (Yes it works pretty well!)
+
+/*!
+ *  @brief      Default constructor
+ */
+Adafruit_MPR121::Adafruit_MPR121() {}
+
+/*!
+ *  @brief    Begin an MPR121 object on a given I2C bus. This function resets
+ *            the device and writes the default settings.
+ *  @param    sensibility5C
+ *            together with sensibility5D sets the sensibility of the touch sensors 
+ *  @param    sensibility5D
+ *  @param    i2caddr
+ *            the i2c address the device can be found on. Defaults to 0x5A.
+ *  @param    *theWire
+ *            Wire object
+ *  @param    touchThreshold
+ *            touch detection threshold value
+ *  @param    releaseThreshold
+ *            release detection threshold value
+ *  @returns  true on success, false otherwise
+ */
+bool Adafruit_MPR121::begin(uint8_t sensibility5C, uint8_t sensibility5D, 
+                            uint8_t i2caddr, TwoWire *theWire,
+                            uint8_t touchThreshold, uint8_t releaseThreshold) {
+  if (i2c_dev) {
+    delete i2c_dev;
+  }
+  i2c_dev = new Adafruit_I2CDevice(i2caddr, theWire);
+
+  if (!i2c_dev->begin()) {
+    return false;
+  }
+
+  // soft reset
+  writeRegister(MPR121_SOFTRESET, 0x63);
+  delay(1);
+  for (uint8_t i = 0; i < 0x7F; i++) {
+    //  Serial.print("$"); Serial.print(i, HEX);
+    //  Serial.print(": 0x"); Serial.println(readRegister8(i));
+  }
+
+  writeRegister(MPR121_ECR, 0x80);
+  // writeRegister(MPR121_ECR, 0x0);
+
+  uint8_t c = readRegister8(MPR121_CONFIG2);
+
+  if (c != 0x24) return false;
+
+  setThresholds(touchThreshold, releaseThreshold);
+  writeRegister(MPR121_MHDR, 0x01);
+  writeRegister(MPR121_NHDR, 0x01);
+  writeRegister(MPR121_NCLR, 0x0E);
+  writeRegister(MPR121_FDLR, 0x00);
+
+  writeRegister(MPR121_MHDF, 0x01);
+  writeRegister(MPR121_NHDF, 0x05);
+  writeRegister(MPR121_NCLF, 0x01);
+  writeRegister(MPR121_FDLF, 0x00);
+
+  writeRegister(MPR121_NHDT, 0x00);
+  writeRegister(MPR121_NCLT, 0x00);
+  writeRegister(MPR121_FDLT, 0x00);
+
+  // writeRegister(MPR121_DEBOUNCE, 0x32);
+  // change this values to extend the range of the sensibility of the sensors
+  writeRegister(MPR121_CONFIG1, sensibility5C);  
+  writeRegister(MPR121_CONFIG2, sensibility5D);  
+  
+#ifdef AUTOCONFIG
+  writeRegister(MPR121_AUTOCONFIG0, 0x2B);
+  // writeRegister(MPR121_AUTOCONFIG0, 0x20);
+
+  // correct values for Vdd = 3.3V
+  writeRegister(MPR121_UPLIMIT, 200);      // ((Vdd - 0.7)/Vdd) * 256
+  writeRegister(MPR121_TARGETLIMIT, 180);  // UPLIMIT * 0.9
+  writeRegister(MPR121_LOWLIMIT, 130);     // UPLIMIT * 0.65
+#endif
+
+  // enable X electrodes and start MPR121
+  byte ECR_SETTING =
+      0b10000000 + 12;  // 5 bits for baseline tracking & proximity disabled + X
+                        // amount of electrodes running (12)
+  writeRegister(MPR121_ECR, ECR_SETTING);  // start with above ECR setting
+
+  return true;
+}
+
+/*!
+ *  @brief      DEPRECATED. Use Adafruit_MPR121::setThresholds(uint8_t touch,
+ *              uint8_t release) instead.
+ *  @param      touch
+ *              see Adafruit_MPR121::setThresholds(uint8_t touch, uint8_t
+ * *release)
+ *  @param      release
+ *              see Adafruit_MPR121::setThresholds(uint8_t touch, *uint8_t
+ * release)
+ */
+void Adafruit_MPR121::setThreshholds(uint8_t touch, uint8_t release) {
+  setThresholds(touch, release);
+}
+
+/*!
+ *  @brief      Set the touch and release thresholds for all 13 channels on the
+ *              device to the passed values. The threshold is defined as a
+ *              deviation value from the baseline value, so it remains constant
+ * even baseline value changes. Typically the touch threshold is a little bigger
+ * than the release threshold to touch debounce and hysteresis. For typical
+ * touch application, the value can be in range 0x05~0x30 for example. The
+ * setting of the threshold is depended on the actual application. For the
+ * operation details and how to set the threshold refer to application note
+ * AN3892 and MPR121 design guidelines.
+ *  @param      touch
+ *              the touch threshold value from 0 to 255.
+ *  @param      release
+ *              the release threshold from 0 to 255.
+ */
+void Adafruit_MPR121::setThresholds(uint8_t touch, uint8_t release) {
+  // set all thresholds (the same)
+  for (uint8_t i = 0; i < 12; i++) {
+    writeRegister(MPR121_TOUCHTH_0 + 2 * i, touch);
+    writeRegister(MPR121_RELEASETH_0 + 2 * i, release);
+  }
+}
+
+/*!
+ *  @brief      Read the filtered data from channel t. The ADC raw data outputs
+ *              run through 3 levels of digital filtering to filter out the high
+ * frequency and low frequency noise encountered. For detailed information on
+ * this filtering see page 6 of the device datasheet.
+ *  @param      t
+ *              the channel to read
+ *  @returns    the filtered reading as a 10 bit unsigned value
+ */
+uint16_t Adafruit_MPR121::filteredData(uint8_t t) {
+  if (t > 12) return 0;
+  return readRegister16(MPR121_FILTDATA_0L + t * 2);
+}
+
+/*!
+ *  @brief      Read the baseline value for the channel. The 3rd level filtered
+ *              result is internally 10bit but only high 8 bits are readable
+ * from registers 0x1E~0x2A as the baseline value output for each channel.
+ *  @param      t
+ *              the channel to read.
+ *  @returns    the baseline data that was read
+ */
+uint16_t Adafruit_MPR121::baselineData(uint8_t t) {
+  if (t > 12) return 0;
+  uint16_t bl = readRegister8(MPR121_BASELINE_0 + t);
+  return (bl << 2);
+}
+
+/**
+ *  @brief      Read the touch status of all 13 channels and the over current 
+ * status in a 16 bit integer. 
+ *  @returns    a 16 bit integer where the 12 lower bits contain the touch status of
+ * the 12 touch sensors. Then, the 13th bit contains the status of the proximiti sensor, 
+ * if used. The highest bit contains the status of the over current flag. 
+ */
+uint16_t Adafruit_MPR121::touched(void) {
+  uint16_t t = readRegister16(MPR121_TOUCHSTATUS_L);
+  return t & 0x9FFF;
+}
+
+/*!
+ *  @brief      Read the contents of an 8 bit device register.
+ *  @param      reg the register address to read from
+ *  @returns    the 8 bit value that was read.
+ */
+uint8_t Adafruit_MPR121::readRegister8(uint8_t reg) {
+  Adafruit_BusIO_Register thereg = Adafruit_BusIO_Register(i2c_dev, reg, 1);
+
+  return (thereg.read());
+}
+
+/*!
+ *  @brief      Check if during the configuration or the auto-configuration the sensors 
+ went out of range, hence no touch could be sensed. Only the 2 ightest bits are checked 
+ because they are the bits that inform about this error. Even if the ids of the failing 
+ channels are set in the lowest bits, this is not used here. 
+ *  @returns    true if the configuration or the auto-configuration could not be performed. 
+ */
+bool Adafruit_MPR121::wentOutOfRange(void) {
+  uint16_t e = readRegister8(MPR121_STATUS_H);
+
+  // check for bits 1100 0000.
+  return (e & 0xC0);
+}
+
+/*!
+* @brief Check if the sensor had an over current, hence it's in an error status an no 
+* sensing could be performed. It does it by checking the highest bit of the touched array 
+* (see page 11 in sensor documnetation).
+* @param touched the array with the results of the touch check, where the highest contains 
+* the error status
+* @returns true if the sensor had an over current, false otherwise
+*/
+bool Adafruit_MPR121::hadOverCurrent(uint16_t touched) {
+  return (touched & 0x8000);
+  }
+
+/*!
+ *  @brief      Read the contents of a 16 bit device register.
+ *  @param      reg the register address to read from
+ *  @returns    the 16 bit value that was read.
+ */
+uint16_t Adafruit_MPR121::readRegister16(uint8_t reg) {
+  Adafruit_BusIO_Register thereg =
+      Adafruit_BusIO_Register(i2c_dev, reg, 2, LSBFIRST);
+
+  return (thereg.read());
+}
+
+/*!
+    @brief  Writes 8-bits to the specified destination register
+    @param  reg the register address to write to
+    @param  value the value to write
+*/
+void Adafruit_MPR121::writeRegister(uint8_t reg, uint8_t value) {
+  // MPR121 must be put in Stop Mode to write to most registers
+  bool stop_required = true;
+
+  // first get the current set value of the MPR121_ECR register
+  Adafruit_BusIO_Register ecr_reg =
+      Adafruit_BusIO_Register(i2c_dev, MPR121_ECR, 1);
+
+  uint8_t ecr_backup = ecr_reg.read();
+  if ((reg == MPR121_ECR) || ((0x73 <= reg) && (reg <= 0x7A))) {
+    stop_required = false;
+  }
+
+  if (stop_required) {
+    // clear this register to set stop mode
+    ecr_reg.write(0x00);
+  }
+
+  Adafruit_BusIO_Register the_reg = Adafruit_BusIO_Register(i2c_dev, reg, 1);
+  the_reg.write(value);
+
+  if (stop_required) {
+    // write back the previous set ECR settings
+    ecr_reg.write(ecr_backup);
+  }
+}

--- a/Arduino/libraries/Adafruit MPR121/Adafruit_MPR121.h
+++ b/Arduino/libraries/Adafruit MPR121/Adafruit_MPR121.h
@@ -1,0 +1,119 @@
+/*!
+ *  @file Adafruit_MPR121.h
+ *
+ *  This is a library for the MPR121 12-Channel Capacitive Sensor
+ *
+ *  Designed specifically to work with the MPR121 board.
+ *
+ *  Pick one up today in the adafruit shop!
+ *  ------> https://www.adafruit.com/product/1982
+ *
+ *  These sensors use I2C to communicate, 2+ pins are required to interface
+ *
+ *  Adafruit invests time and resources providing this open source code,
+ *  please support Adafruit andopen-source hardware by purchasing products
+ *  from Adafruit!
+ *
+ *  Limor Fried/Ladyada (Adafruit Industries).
+ *
+ *  BSD license, all text above must be included in any redistribution
+ */
+
+#ifndef ADAFRUIT_MPR121_H
+#define ADAFRUIT_MPR121_H
+
+#include "Arduino.h"
+#include <Adafruit_BusIO_Register.h>
+#include <Adafruit_I2CDevice.h>
+
+// The default I2C address
+#define MPR121_I2CADDR_DEFAULT 0x5A        ///< default I2C address
+#define MPR121_TOUCH_THRESHOLD_DEFAULT 12  ///< default touch threshold value
+#define MPR121_RELEASE_THRESHOLD_DEFAULT 6 ///< default relese threshold value
+
+/*!
+ *  Device register map
+ */
+enum {
+  MPR121_TOUCHSTATUS_L = 0x00,
+  MPR121_TOUCHSTATUS_H = 0x01,
+  MPR121_STATUS_L = 0x02,
+  MPR121_STATUS_H = 0x03,
+  MPR121_FILTDATA_0L = 0x04,
+  MPR121_FILTDATA_0H = 0x05,
+  MPR121_BASELINE_0 = 0x1E,
+  MPR121_MHDR = 0x2B,
+  MPR121_NHDR = 0x2C,
+  MPR121_NCLR = 0x2D,
+  MPR121_FDLR = 0x2E,
+  MPR121_MHDF = 0x2F,
+  MPR121_NHDF = 0x30,
+  MPR121_NCLF = 0x31,
+  MPR121_FDLF = 0x32,
+  MPR121_NHDT = 0x33,
+  MPR121_NCLT = 0x34,
+  MPR121_FDLT = 0x35,
+
+  MPR121_TOUCHTH_0 = 0x41,
+  MPR121_RELEASETH_0 = 0x42,
+  MPR121_DEBOUNCE = 0x5B,
+  MPR121_CONFIG1 = 0x5C,
+  MPR121_CONFIG2 = 0x5D,
+  MPR121_CHARGECURR_0 = 0x5F,
+  MPR121_CHARGETIME_1 = 0x6C,
+  MPR121_ECR = 0x5E,
+  MPR121_AUTOCONFIG0 = 0x7B,
+  MPR121_AUTOCONFIG1 = 0x7C,
+  MPR121_UPLIMIT = 0x7D,
+  MPR121_LOWLIMIT = 0x7E,
+  MPR121_TARGETLIMIT = 0x7F,
+
+  MPR121_GPIODIR = 0x76,
+  MPR121_GPIOEN = 0x77,
+  MPR121_GPIOSET = 0x78,
+  MPR121_GPIOCLR = 0x79,
+  MPR121_GPIOTOGGLE = 0x7A,
+
+  MPR121_SOFTRESET = 0x80,
+};
+
+//.. thru to 0x1C/0x1D
+
+/*!
+ *  @brief  Class that stores state and functions for interacting with MPR121
+ *  proximity capacitive touch sensor controller.
+ */
+class Adafruit_MPR121 {
+public:
+  // Hardware I2C
+  Adafruit_MPR121();
+
+  bool begin(uint8_t sensibility5C, uint8_t sensibility5D,
+             uint8_t i2caddr = MPR121_I2CADDR_DEFAULT, 
+             TwoWire *theWire = &Wire, 
+             uint8_t touchThreshold = MPR121_TOUCH_THRESHOLD_DEFAULT,
+             uint8_t releaseThreshold = MPR121_RELEASE_THRESHOLD_DEFAULT);
+
+  uint16_t filteredData(uint8_t t);
+  uint16_t baselineData(uint8_t t);
+
+  uint8_t readRegister8(uint8_t reg);
+  uint16_t readRegister16(uint8_t reg);
+  void writeRegister(uint8_t reg, uint8_t value);
+  uint16_t touched(void);
+  // Add deprecated attribute so that the compiler shows a warning
+  void setThreshholds(uint8_t touch, uint8_t release)
+      __attribute__((deprecated));
+  void setThresholds(uint8_t touch, uint8_t release);
+
+  // Function that checks if any of the sensors went our of rance
+  bool wentOutOfRange();
+
+  // Function that checks if any of the sensors had an overcurrent
+  bool hadOverCurrent(uid_t touched);
+
+private:
+  Adafruit_I2CDevice *i2c_dev = NULL;
+};
+
+#endif

--- a/Arduino/libraries/Adafruit MPR121/README.md
+++ b/Arduino/libraries/Adafruit MPR121/README.md
@@ -1,0 +1,17 @@
+# Adafruit MPR121 Library [![Build Status](https://github.com/adafruit/Adafruit_MPR121/workflows/Arduino%20Library%20CI/badge.svg)](https://github.com/adafruit/Adafruit_MPR121/actions)
+
+
+<a href="https://www.adafruit.com/products/1982"><img src="https://cdn-shop.adafruit.com/970x728/1982-00.jpg" height="300"/></a>
+
+Tested and works great with the Adafruit MPR121
+  * https://www.adafruit.com/products/1982
+  * https://www.adafruit.com/product/2024
+  * https://www.adafruit.com/product/2340
+ 
+Check out the links above for our tutorials and wiring diagrams. 
+These sensors use I2C to communicate, 2+ pins are required to interface
+
+Adafruit invests time and resources providing this open source code, please support Adafruit and open-source hardware by purchasing products from Adafruit!
+
+Written by Limor Fried/Ladyada (Adafruit Industries).
+MIT license, all text above must be included in any redistribution

--- a/Arduino/libraries/Adafruit MPR121/keywords.txt
+++ b/Arduino/libraries/Adafruit MPR121/keywords.txt
@@ -1,0 +1,6 @@
+Adafruit_MPR121	KEYWORD1
+begin	KEYWORD2
+filteredData	KEYWORD2
+baselineData	KEYWORD2
+touched	KEYWORD2
+setThresholds	KEYWORD2

--- a/Arduino/libraries/Adafruit MPR121/library.properties
+++ b/Arduino/libraries/Adafruit MPR121/library.properties
@@ -1,0 +1,10 @@
+name=Adafruit MPR121
+version=1.1.0
+author=Adafruit <info@adafruit.com>
+maintainer=Adafruit <info@adafruit.com>
+sentence=Arduino library for the MPR121-based capacitive sensors in the Adafruit shop.
+paragraph=Designed specifically to work with the MPR121 Breakout in the Adafruit shop.
+category=Sensors
+url=https://github.com/adafruit/Adafruit_MPR121
+architectures=*
+depends=Adafruit BusIO

--- a/Arduino/libraries/ST_Anything_Adafruit_MPR121/PS_Adafruit_MPR121.cpp
+++ b/Arduino/libraries/ST_Anything_Adafruit_MPR121/PS_Adafruit_MPR121.cpp
@@ -1,0 +1,175 @@
+//******************************************************************************************
+//  File: PS_Adafruit_MPR121.cpp
+//  Authors: Luca Masera
+//
+//  Summary:  PS_Adafruit_MPR121 is a class that inherits from the st::InterruptSensor class.
+//
+//  Create an instance of this class in your sketch's global variable section. 
+//  For Example:  st::PS_Adafruit_MPR121 sensor(F("button1"), 5, 0x10, 0x20, 1000);
+//
+//	st::PS_Adafruit_MPR121() constructor requires the following arguments
+//  - String &name - REQUIRED - the name of the object, should be "touchButtons_Kitchen", "touchButtons_Desk", etc...
+//  - int8_t activatedButtonId - REQUIRED - the id of the sensor that is used to activate the touching capability
+//  - uint8_t sensibility5C = 0x10, together with sensibility5D sets the sensibility of the touch sensors
+//  - uint8_t sensibility5D = 0x20,
+//	- long reqNumMillisHeld = 1000 - milliseconds thesholdb between "Held" and "Pushed"
+//
+//  Change History:
+//
+//    Date        Who            What
+//    ----        ---            ----
+//    2022-09-22  Luca Masera    Original creation
+//
+//******************************************************************************************
+
+#include "PS_Adafruit_MPR121.h"
+
+#include "Constants.h"
+#include "Everything.h"
+
+namespace st {
+// private
+
+// public
+// constructor
+PS_Adafruit_MPR121::PS_Adafruit_MPR121(const __FlashStringHelper *name,
+                                       int8_t activateButtonId,
+                                       uint8_t sensibility5C,
+                                       uint8_t sensibility5D,
+                                       long reqNumMillisHeld)
+    : InterruptSensor(name, 2, false),  // use parent class' constructor
+      m_sensibility5C(sensibility5C),
+      m_sensibility5D(sensibility5D),
+      m_lreqNumMillisHeld(reqNumMillisHeld),
+      activateButtonId(activateButtonId){}
+
+// destructor
+PS_Adafruit_MPR121::~PS_Adafruit_MPR121() {}
+
+void PS_Adafruit_MPR121::init() {
+  // get current status of motion sensor by calling parent class's
+  // init() routine - no need to duplicate it here!
+  InterruptSensor::init();
+
+  Serial.println("Adafruit MPR121 Capacitive Touch sensor");
+
+  // Default address is 0x5A, if tied to 3.3V its 0x5B
+  // If tied to SDA its 0x5C and if SCL then 0x5D
+  if (!cap.begin(0x5A, m_sensibility5C, m_sensibility5D)) {
+    Serial.println(F("MPR121 not found, check wiring?"));
+
+  } else {
+    Serial.println(F("MPR121 found!"));
+    refresh();
+  }
+}
+
+// called periodically by Everything class to ensure ST Cloud is kept up yo
+// date. HOWEVER, not useful for the IS_Button.
+void PS_Adafruit_MPR121::refresh() {
+  if (isBlockedStatus) {
+    isBlockedStatus = false;
+    Serial.println("Blocked status: trying to perform a soft reset to restart the sensor.");
+
+    this->init();
+  }
+
+  // Send 'init' message to allow Parent Driver to set numberOfButtons
+  // attribute automatically
+  Everything::sendSmartString(getName() + F(" init"));
+}
+
+void PS_Adafruit_MPR121::update() {  // Get the currently touched pads
+// get current time 
+long currentTime = millis();
+
+// get current touch array
+curr_touched = cap.touched();
+
+// had an over current or out of range?
+isBlockedStatus = cap.hadOverCurrent(curr_touched) || cap.wentOutOfRange();
+
+if (!isBlockedStatus) {
+  
+  // A) if not active...
+  if (!isActive) {
+    // B) if the touch is to activate the sensor (ACTIVATE_BUTTON)... 
+    if (bitRead(curr_touched, activateButtonId) && !(bitRead(curr_touched, activateButtonId))) {
+      //    register activation time and ...
+      Serial.println(F("activation touched"));
+      activationStart = currentTime;
+    
+    } else if (!(bitRead(old_touched, activateButtonId)) && bitRead(curr_touched, activateButtonId)) {
+      // C) if the activation time is bigger than the ACTIVATION_THRESOLD... 
+      if (currentTime - activationStart > _ACTIVATION_THRESOLD) {
+        // activate the sensor and register active time
+        Serial.println(F("activated"));
+        waitingActive = currentTime;
+        isActive = true;
+      }
+    }
+
+  // ... is active
+  } else {
+    // D) first check if still active, or at least hold
+    if ((currentTime - waitingActive > _ACTIVE_TIMEOUT) && !isHold) {
+      // if not, deactivate the sensor
+      Serial.println(F("deactivated"));
+      isActive = false;
+
+    } else {
+      // is active or hold, check what's going on with the buttons
+      // for each button (we have 12), check the status of the bit in the touch array (ignore ACTIVATE_BUTTON)
+      for (uint8_t currentButton = 0; currentButton < 12; currentButton++) {
+        if (currentButton != activateButtonId) {
+          // E) if positive and different from the old status then ...
+          if (bitRead(curr_touched, currentButton) && !(bitRead(old_touched, currentButton))) {
+            //... is a touch: register the TOUCH and store the touch time (for hold status)
+            Serial.print("touched: ");
+            Serial.println(currentButton);
+            startTouch[currentButton] = currentTime;
+            waitingActive = currentTime;
+            Everything::sendSmartStringNow(getName() + String(currentButton) + _PUSHED);
+            
+            // F) if positive and equal to the old status then ...
+            } else if (bitRead(curr_touched, currentButton) && (bitRead(old_touched, currentButton))) {
+              // ... G) it could be a hold: if the HOLD_THRESOLD has been reached for the current button...
+              if (!(bitRead(isHold, currentButton)) && (currentTime - startTouch[currentButton] > HOLD_THRESOLD)) {
+                // ... register the HOLD and store a flag for the button
+                Serial.print("held: ");
+                Serial.println(currentButton);
+                bitSet(isHold, currentButton);
+                waitingActive = currentTime;
+                Everything::sendSmartString(getName() + String(currentButton) + _HELD);
+              }
+
+            // H) if negative and different from the old status then ... 
+            } else if (!(bitRead(curr_touched, currentButton)) && bitRead(old_touched, currentButton)) {
+            // ... it means that there's no touch anymore 
+            // I) if it was hold... 
+            if (bitRead(isHold, currentButton)) {
+            // ... reset the flag for the button
+              Serial.print("stop held: ");
+              Serial.println(currentButton);
+              bitClear(isHold, currentButton);
+            }
+            // register the RELEASE for the button
+            Serial.print("released: ");
+            Serial.println(currentButton);
+            Everything::sendSmartString(getName() + String(currentButton) + _RELEASED);
+            }
+        }
+      }
+
+      old_touched = curr_touched;
+      }
+    }
+  }
+}
+  
+
+void PS_Adafruit_MPR121::runInterrupt() {}
+
+void PS_Adafruit_MPR121::runInterruptEnded() {}
+
+}  // namespace st

--- a/Arduino/libraries/ST_Anything_Adafruit_MPR121/PS_Adafruit_MPR121.cpp
+++ b/Arduino/libraries/ST_Anything_Adafruit_MPR121/PS_Adafruit_MPR121.cpp
@@ -17,7 +17,7 @@
 //  Change History:
 //
 //    Date        Who            What
-//    ----        ---            ----
+//    2022-09-23  Luca Masera    Corrected bugs within inizialization and check of buttons status
 //    2022-09-22  Luca Masera    Original creation
 //
 //******************************************************************************************
@@ -55,7 +55,7 @@ void PS_Adafruit_MPR121::init() {
 
   // Default address is 0x5A, if tied to 3.3V its 0x5B
   // If tied to SDA its 0x5C and if SCL then 0x5D
-  if (!cap.begin(0x5A, m_sensibility5C, m_sensibility5D)) {
+  if (!cap.begin(m_sensibility5C, m_sensibility5D, 0x5A)) {
     Serial.println(F("MPR121 not found, check wiring?"));
 
   } else {
@@ -94,12 +94,12 @@ if (!isBlockedStatus) {
   // A) if not active...
   if (!isActive) {
     // B) if the touch is to activate the sensor (ACTIVATE_BUTTON)... 
-    if (bitRead(curr_touched, activateButtonId) && !(bitRead(curr_touched, activateButtonId))) {
+    if (bitRead(curr_touched, activateButtonId) && !(bitRead(old_touched, activateButtonId))) {
       //    register activation time and ...
       Serial.println(F("activation touched"));
       activationStart = currentTime;
     
-    } else if (!(bitRead(old_touched, activateButtonId)) && bitRead(curr_touched, activateButtonId)) {
+    } else if ((bitRead(old_touched, activateButtonId)) && bitRead(old_touched, activateButtonId)) {
       // C) if the activation time is bigger than the ACTIVATION_THRESOLD... 
       if (currentTime - activationStart > _ACTIVATION_THRESOLD) {
         // activate the sensor and register active time
@@ -158,13 +158,13 @@ if (!isBlockedStatus) {
             Serial.println(currentButton);
             Everything::sendSmartString(getName() + String(currentButton) + _RELEASED);
             }
+          }
         }
-      }
-
-      old_touched = curr_touched;
       }
     }
   }
+  
+  old_touched = curr_touched;
 }
   
 

--- a/Arduino/libraries/ST_Anything_Adafruit_MPR121/PS_Adafruit_MPR121.h
+++ b/Arduino/libraries/ST_Anything_Adafruit_MPR121/PS_Adafruit_MPR121.h
@@ -1,0 +1,96 @@
+//******************************************************************************************
+//  File: PS_Adafruit_MPR121.h
+//  Authors: Luca Masera
+//
+//  Summary:  PS_Adafruit_MPR121 is a class which implements the SmartThings
+//  "Contact Sensor" device capability.
+//  It inherits from the st::InterruptSensor class.
+//
+//  Create an instance of this class in your sketch's
+//  global variable section 			  For Example:
+//  st::PS_Adafruit_MPR121 sensor(F("touchButtons"), 5);
+//
+//	st::PS_Adafruit_MPR121() constructor requires the following arguments
+//  - String &name - REQUIRED - the name of the object, should be "touchButtons_Kitchen", "touchButtons_Desk", etc...
+//  - int8_t activatedButtonId - REQUIRED - the id of the sensor that is used to activate the touching capability
+//  - uint8_t sensibility5C = 0x10, together with sensibility5D sets the sensibility of the touch sensors
+//  - uint8_t sensibility5D = 0x20,
+//	- long reqNumMillisHeld = 1000 - milliseconds thesholdb between "Held" and "Pushed"
+//  - 
+//(default = 1000)
+//
+//  Change History:
+//
+//    Date        Who            What
+//    ----        ---            ----
+//    2022-09-22  Luca Masera    Original Creation
+//
+//******************************************************************************************
+
+#ifndef ST_PS_ADAFRUIT_MPR121_H
+#define ST_PS_ADAFRUIT_MPR121_H
+
+#include <Adafruit_MPR121.h>
+
+#include "InterruptSensor.h"
+
+namespace st {
+class PS_Adafruit_MPR121 : public InterruptSensor {
+  private:
+  unsigned long m_lTimeBtnPressed;    // time when the digital input went high
+  unsigned long m_lreqNumMillisHeld;  // amount of time required to trigger "held" instead of "pushed"
+
+  uint8_t m_sensibility5C; // couple of values used to set the default sensitivity of the sensors
+  uint8_t m_sensibility5D;
+
+  bool m_bFirstRun = true;   // used to prevent sending inadvertent button
+                             // pushed/held message on startup
+  bool m_bHeldSent = false;  // used to prevent sending multiple 'held' messages
+  bool isBlockedStatus = false; // ued to inform if the sensor is blocked and needs a reset
+
+  const __FlashStringHelper *_PUSHED = F(" pushed");
+  const __FlashStringHelper *_HELD = F(" held");
+  const __FlashStringHelper *_RELEASED = F(" released");
+
+  u_int16_t _ACTIVATION_THRESOLD = 2000;
+  u_int16_t _ACTIVE_TIMEOUT = 1200;
+  u_int16_t HOLD_THRESOLD = 800;
+  boolean isActive = false;
+
+
+  int8_t activateButtonId;
+  uint16_t curr_touched, old_touched, isTouched, isHold;
+  long currentTime, activationStart, waitingActive, startTouch[12];
+
+  Adafruit_MPR121 cap = Adafruit_MPR121();
+  
+  public:
+  // constructor - called in your sketch's global variable declaration section
+  PS_Adafruit_MPR121(const __FlashStringHelper *name, 
+                    int8_t activateButtonId, 
+                    uint8_t sensibility5C = 0x10, // defaults to low sensibility for almost touch
+                    uint8_t sensibility5D = 0x20,
+                    long reqNumMillisHeld = 1000); //defaults to 1 second  
+
+  // destructor
+  virtual ~PS_Adafruit_MPR121();
+
+  // initialization function
+  virtual void init();
+
+  // called periodically by Everything class to ensure ST Cloud is kept up to
+  // date.  Not used for IS_Button.
+  virtual void refresh();
+
+  // handles what to do when interrupt is triggered
+  virtual void runInterrupt();
+
+  // handles what to do when interrupt is ended
+  virtual void runInterruptEnded();
+
+  // override update method
+  virtual void update();
+  };
+}  // namespace st
+
+#endif

--- a/Arduino/libraries/ST_Anything_Adafruit_MPR121/PS_Adafruit_MPR121.h
+++ b/Arduino/libraries/ST_Anything_Adafruit_MPR121/PS_Adafruit_MPR121.h
@@ -52,8 +52,8 @@ class PS_Adafruit_MPR121 : public InterruptSensor {
   const __FlashStringHelper *_HELD = F(" held");
   const __FlashStringHelper *_RELEASED = F(" released");
 
-  u_int16_t _ACTIVATION_THRESOLD = 2000;
-  u_int16_t _ACTIVE_TIMEOUT = 1200;
+  u_int16_t _ACTIVATION_THRESOLD = 1000;
+  u_int16_t _ACTIVE_TIMEOUT = 2000;
   u_int16_t HOLD_THRESOLD = 800;
   boolean isActive = false;
 


### PR DESCRIPTION
Added support for the MPR121 touch board.

Current status: completed

Behaviour: a button, configurable from the code, is used as master switch. If OFF no sensors are enabled, if ON the other 11 sensors are active. The status PUSHED, HELD and RELEASED are sent to the HUB.

The sensor is configurable from the code and allows to set the name of the sensor, which button is the master switch, the sensibility of the touch and the timeout to decide between PUSH and HELD. 